### PR TITLE
Fix timezone issues in EwsUtilities and ExchangeServiceBase

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/EwsUtilities.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsUtilities.java
@@ -782,6 +782,7 @@ class EwsUtilities {
 		} else if (cls.isInstance(new Date())) {
 			Object o = null;
 			DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+            df.setTimeZone(TimeZone.getTimeZone("UTC"));
 			return (T) df.parse(value);
 		} else if (cls.isInstance(Boolean.valueOf(false)))
 		// else if( cls.isInstance(new Boolean(false)))
@@ -878,6 +879,7 @@ class EwsUtilities {
 	static String dateTimeToXSDate(Date date) {
 		String format = "yyyy-MM-dd'Z'";
 		DateFormat utcFormatter = new SimpleDateFormat(format);
+		utcFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 		return utcFormatter.format(date);
 	}
 
@@ -891,6 +893,7 @@ class EwsUtilities {
 	protected static String dateTimeToXSDateTime(Date date) {
 		String format = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 		DateFormat utcFormatter = new SimpleDateFormat(format);
+		utcFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 		return utcFormatter.format(date);
 	}
 	

--- a/src/main/java/microsoft/exchange/webservices/data/ExchangeServiceBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExchangeServiceBase.java
@@ -499,21 +499,25 @@ public abstract class ExchangeServiceBase {
 			if (dateString.endsWith("Z")) {
 				// String in UTC format yyyy-MM-ddTHH:mm:ssZ
 				utcFormatter = new SimpleDateFormat(utcPattern);
+				utcFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 				try {
 					dt = utcFormatter.parse(dateString);
 				} catch (ParseException e) {
 					utcFormatter = new SimpleDateFormat(pattern);
+					utcFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 					//	dateString = dateString.substring(0, 10)+"T12:00:00Z";
 					try {
 						dt = utcFormatter.parse(dateString);
 					} catch (ParseException e1) {
 						utcFormatter = new SimpleDateFormat(localPattern1);
+						utcFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 
 						try {
 							dt = utcFormatter.parse(dateString);
-						}catch(ParseException ex){
+						} catch (ParseException ex){
 							
 							utcFormatter = new SimpleDateFormat(utcPattern1);
+							utcFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 						}
 							try{
 							dt = utcFormatter.parse(dateString);
@@ -528,6 +532,7 @@ public abstract class ExchangeServiceBase {
 			} else if (dateString.endsWith("z")) {
 				// String in UTC format yyyy-MM-ddTHH:mm:ssZ
 				utcFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'z'");
+				utcFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 				try {
 					dt = utcFormatter.parse(dateString);
 				} catch (ParseException e) {
@@ -547,10 +552,12 @@ public abstract class ExchangeServiceBase {
 					dateString = String.format("%sGMT%s", date, zone);
 					try {
 						utcFormatter = new SimpleDateFormat(localPattern);
+						utcFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 						dt = utcFormatter.parse(dateString);
 					} catch (ParseException e) {
 						try {
 							utcFormatter = new SimpleDateFormat(pattern);
+							utcFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 							dt = utcFormatter.parse(dateString);
 						} catch (ParseException ex) {
 							throw new IllegalArgumentException(ex);
@@ -559,9 +566,10 @@ public abstract class ExchangeServiceBase {
 				} else {
 					// Invalid format
 					utcFormatter = new SimpleDateFormat(localPattern2);
+					utcFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 					try {
 						dt = utcFormatter.parse(dateString);
-					} catch (ParseException e) {						
+					} catch (ParseException e) {
 						e.printStackTrace();
 						throw new IllegalArgumentException(errMsg);
 					}
@@ -580,16 +588,16 @@ public abstract class ExchangeServiceBase {
 	 *            The string value to parse.
 	 * @return The parsed DateTime value.
 	 */
-    protected Date convertStartDateToUnspecifiedDateTime(String value) 
+	protected Date convertStartDateToUnspecifiedDateTime(String value)
 			throws ParseException {
-        if (value == null || value.isEmpty()) {
-            return null;
-        } else {
-        	DateFormat df = new SimpleDateFormat("yyyy-MM-dd'Z'");
+		if (value == null || value.isEmpty()) {
+			return null;
+		} else {
+			DateFormat df = new SimpleDateFormat("yyyy-MM-dd'Z'");
 			return df.parse(value);
-        }
-    }
-    
+		}
+	}
+
 	/**
 	 * Converts the date time to universal date time string.
 	 * 
@@ -598,10 +606,9 @@ public abstract class ExchangeServiceBase {
 	 * @return String representation of DateTime in yyyy-MM-ddTHH:mm:ssZ format.
 	 */
 	protected String convertDateTimeToUniversalDateTimeString(Date dt) {
-
-		DateFormat utcFormatter = null;
 		String utcPattern = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-		utcFormatter = new SimpleDateFormat(utcPattern);
+		DateFormat utcFormatter = new SimpleDateFormat(utcPattern);
+		utcFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
 		return utcFormatter.format(dt);
 	}
 


### PR DESCRIPTION
The timezone should be set to UTC explicitly to work on systems with a non-UTC timezone.
