### PR TITLE
Clean up dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,12 @@
         </dependency>
 
         <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
+        </dependency>
+
+        <dependency>
             <groupId>jcifs</groupId>
             <artifactId>jcifs</artifactId>
             <version>1.3.17</version>


### PR DESCRIPTION
`commons-codec` and `commons-logging` are only used by the `commons-httpclient` dependency, so there should be no need to specify them explicitly and use different version than required by `commons-httpclient`.
