### PR TITLE
Use commons-logging instead of printing to stdout

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/EwsSSLProtocolSocketFactory.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsSSLProtocolSocketFactory.java
@@ -21,6 +21,8 @@ import org.apache.commons.httpclient.ConnectTimeoutException;
 import org.apache.commons.httpclient.HttpClientError;
 import org.apache.commons.httpclient.params.HttpConnectionParams;
 import org.apache.commons.httpclient.protocol.SecureProtocolSocketFactory;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * <p>
@@ -69,7 +71,9 @@ import org.apache.commons.httpclient.protocol.SecureProtocolSocketFactory;
 
 class EwsSSLProtocolSocketFactory implements SecureProtocolSocketFactory {
 
-	/** The SSL Context. */
+    private static final Log log = LogFactory.getLog(EwsSSLProtocolSocketFactory.class);
+
+    /** The SSL Context. */
     private SSLContext sslcontext = null;
     
     /** The X509 TrustManager. */
@@ -91,7 +95,7 @@ class EwsSSLProtocolSocketFactory implements SecureProtocolSocketFactory {
               null);
             return context;
         } catch (Exception e) {
-            System.out.println(e.getMessage()+e);
+            log.error(e.getMessage(), e);
             throw new HttpClientError(e.toString());
         }
     }
@@ -201,5 +205,4 @@ class EwsSSLProtocolSocketFactory implements SecureProtocolSocketFactory {
     public int hashCode() {
         return EwsSSLProtocolSocketFactory.class.hashCode();
     }
-
 }

--- a/src/main/java/microsoft/exchange/webservices/data/EwsTraceListener.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsTraceListener.java
@@ -6,49 +6,27 @@
  **************************************************************************/
 package microsoft.exchange.webservices.data;
 
-import java.io.PrintStream;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
- * EwsTraceListener logs request/responses to a text writer.
- * 
- * @see EwsTraceEvent
+ * EwsTraceListener logs request/responses.
  */
 class EwsTraceListener implements ITraceListener {
 
-	/** The writer. */
-	private PrintStream writer;
+	private Log log = LogFactory.getLog(EwsTraceListener.class);
 
-	/**
-	 * Initializes a new instance of the class. Uses System.Out as output.
-	 */
-	protected EwsTraceListener() {
-		this(System.out);
-	}
 
-	/**
-	 * Initializes a new instance of the class.
-	 * 
-	 * @param writer
-	 *            the writer
-	 */
-	protected EwsTraceListener(PrintStream writer) {
-		this.writer = writer;
-	}
+	protected EwsTraceListener() {}
 
 	/**
 	 * Handles a trace message.
 	 * 
-	 * @param traceType
-	 *            the trace type
-	 * @param traceMessage
-	 *            the trace message
+	 * @param traceType     The trace type
+	 * @param traceMessage  The trace message
 	 */
 	@Override
 	public void trace(String traceType, String traceMessage) {
-		// this.writer.println(String.format("%s : %s", traceType,
-		// traceMessage));
-		this.writer.println(traceMessage);
-		this.writer.flush();
+		log.trace(traceType + " - " + traceMessage);
 	}
-
 }


### PR DESCRIPTION
The library prints data to stdout on multiple places, instead of logging to a framework. This pull request address the most import cases only: request/response traces and errors when creating the SSL context.

Note that when this PR is approved, the dependency on commons-logging in Maven's `pom.xml` should not be removed (#35).
