### PR TITLE
Fix for issue #45 : Parse a recurrence range's end date as a date, not as a date-time.

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/EndDateRecurrenceRange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EndDateRecurrenceRange.java
@@ -101,7 +101,7 @@ final class EndDateRecurrenceRange extends RecurrenceRange {
 		} else {
 			if (reader.getLocalName().equals(XmlElementNames.EndDate)) {			
 			
-				Date temp = reader.readElementValueAsDateTime();
+				Date temp = reader.readElementValueAsUnspecifiedDate();
 
 				if(temp!=null) {
 					this.endDate = temp;


### PR DESCRIPTION
The types.xsd file specifies that the type 'EndDate' of the type 'EndDateRecurrenceRange' has a value of type xs:date, not xs:datetime, so invoke the correct parsing method accordingly.
