### PR TITLE
Fix for issue #8 : Return correct schema instance.

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/MeetingMessageSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingMessageSchema.java
@@ -110,6 +110,15 @@ public class MeetingMessageSchema extends EmailMessageSchema {
 		new MeetingMessageSchema();
 
 	/**
+     * Gets the single instance of MeetingMessageSchema.
+     *
+     * @return single instance of MeetingMessageSchema
+     */
+    public static MeetingMessageSchema getInstance() {
+        return Instance;
+    }
+
+	/**
 	 * Registers properties.
 	 * 
 	 * IMPORTANT NOTE: PROPERTIES MUST BE REGISTERED IN SCHEMA ORDER (i.e. the


### PR DESCRIPTION
MeetingMessage should return an instance of MeetingMessageSchema, by overriding the getInstance() method.
