### PR TITLE
Fix for issue #8 : MeetingMessage returns the wrong schema

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/MeetingMessageSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingMessageSchema.java
@@ -108,6 +108,15 @@ public class MeetingMessageSchema extends EmailMessageSchema {
 	/** This must be after the declaration of property definitions. */
 	protected static final MeetingMessageSchema Instance = 
 		new MeetingMessageSchema();
+	
+	/**
+         * Gets the single instance of MeetingMessageSchema.
+         * 
+         * @return single instance of MeetingMessageSchema
+         */
+         public static MeetingMessageSchema getInstance() {
+                return Instance;
+         }
 
 	/**
 	 * Registers properties.


### PR DESCRIPTION
MeetingMessage.getSchema() returns an EmailMessageSchema when it should return the MeetingMessageSchema. This affects the child classes of MeetingCancellation and MeetingResponse. MeetingRequest is not affected.

The issue is that both aforementioned child classes rely on MeetingMessage to return a schema. MeetingMessage.getSchema() calls MeetingMessageSchema.getInstance(). This method is not present on MeetingMessageSchema and goes up to EmailMessageSchema.getInstance(), which returns an EmailMessageSchema for the two classes, omitting additional properties from MeetingMessageSchema.

MeetingMessageSchema should return its own instance directly and not rely on its parent class.

The fix is to override getInstance() in MeetingMessageSchema, so that its superclass' implementation is no longer called.
