### PR TITLE
Only call handle response once in HandingServiceRequestBase

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/HangingServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/HangingServiceRequestBase.java
@@ -253,11 +253,11 @@ abstract class HangingServiceRequestBase extends ServiceRequestBase {
 
 			while (this.isConnected()) {
 				Object responseObject = null;
-				if(traceEWSResponse){
+				if(traceEWSResponse) {
 					/*try{*/
 						EwsServiceMultiResponseXmlReader	ewsXmlReader = EwsServiceMultiResponseXmlReader.create(tracingStream, getService());
 						responseObject = this.readResponse(ewsXmlReader);
-						//this.responseHandler.handleResponseObject(responseObject);
+						this.responseHandler.handleResponseObject(responseObject);
 				/*	}catch(Exception ex){
 						this.disconnect(HangingRequestDisconnectReason.Exception, ex);
 						return;
@@ -274,16 +274,11 @@ abstract class HangingServiceRequestBase extends ServiceRequestBase {
 					responseCopy = new ByteArrayOutputStream();
 					 tracingStream.setResponseCopy(responseCopy);
 					
-				}
-				else {
+				} else {
 					EwsServiceMultiResponseXmlReader	ewsXmlReader = EwsServiceMultiResponseXmlReader.create(tracingStream, getService());
 					responseObject = this.readResponse(ewsXmlReader);
 					this.responseHandler.handleResponseObject(responseObject);
 				}
-				
-
-				this.responseHandler.handleResponseObject(responseObject);
-				
 			}
 		}
 	


### PR DESCRIPTION
Prevents duplicate notifications when streaming events.

I also cleaned up some whitespace.
