### PR TITLE
Fix #62: validatePropertyAccess() in UserConfiguration is wrong

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/UserConfiguration.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UserConfiguration.java
@@ -682,12 +682,11 @@ public class UserConfiguration {
 	 */
 	private void validatePropertyAccess(UserConfigurationProperties property)
 			throws PropertyException {
-		if (this.propertiesAvailableForAccess.contains(property)) {
+		if (!this.propertiesAvailableForAccess.contains(property)) {
 			throw new PropertyException(
 					Strings.MustLoadOrAssignPropertyBeforeAccess, property
 							.toString());
 		}
-
 	}
 
 	/**


### PR DESCRIPTION
The condition for the if statement inside this method was reversed.
