### PR TITLE
Fix #31 and #32 remove useless null checks

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/RemoveFromCalendar.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RemoveFromCalendar.java
@@ -30,8 +30,6 @@ import java.util.List;
 	 */
 	RemoveFromCalendar(Item referenceItem) throws Exception {
 		super(referenceItem.getService());
-		EwsUtilities.EwsAssert(referenceItem != null,
-				"RemoveFromCalendar.ctor", "referenceItem is null");
 
 		referenceItem.throwIfThisIsNew();
 

--- a/src/main/java/microsoft/exchange/webservices/data/SuppressReadReceipt.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SuppressReadReceipt.java
@@ -25,8 +25,6 @@ package microsoft.exchange.webservices.data;
 	 */
 	protected SuppressReadReceipt(Item referenceItem) throws Exception {
 		super(referenceItem.getService());
-		EwsUtilities.EwsAssert(referenceItem != null,
-				"SuppressReadReceipt.ctor", "referenceItem is null");
 
 		referenceItem.throwIfThisIsNew();
 		this.referenceItem = referenceItem;


### PR DESCRIPTION
There are a couple of approaches:
1. Just remove the useless checks.
2. Require caller to pass ReferenceItem and service object separately, pass the service object to the super class, and then validate reference item then use it.

I've decided to go with option 1.
