### PR TITLE
Pull request #90: [java.lang.ClassCastException] When adding HTMLSignature to userConfiguration

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/UserConfigurationDictionary.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UserConfigurationDictionary.java
@@ -342,12 +342,18 @@ public final class UserConfigurationDictionary extends ComplexProperty
                 valueAsString = String.valueOf(dictionaryObject);
             } else if (dictionaryObject instanceof byte[]) {
                 dictionaryObjectType = UserConfigurationDictionaryObjectType.ByteArray;
-                valueAsString = Base64EncoderStream
-                        .encode((byte[]) dictionaryObject);
+                valueAsString = Base64EncoderStream.encode((byte[]) dictionaryObject);
             } else if (dictionaryObject instanceof Byte[]) {
                 dictionaryObjectType = UserConfigurationDictionaryObjectType.ByteArray;
-                valueAsString = Base64EncoderStream
-                        .encode((byte[]) dictionaryObject);
+
+                // cast Byte[] to byte[]
+                Byte[] from = (Byte[]) dictionaryObject;
+                byte[] to = new byte[from.length];
+                for (int currentIndex = 0; currentIndex < from.length; currentIndex++) {
+                    to[currentIndex] = (byte) from[currentIndex];
+                }
+
+                valueAsString = Base64EncoderStream.encode(to);
             } else {
                 throw new IllegalArgumentException(String.format(
                         "Unsupported type: %s", dictionaryObject.getClass()

--- a/src/test/java/microsoft/exchange/webservices/data/UserConfigurationDictionaryTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/UserConfigurationDictionaryTest.java
@@ -81,6 +81,10 @@ public class UserConfigurationDictionaryTest {
         final boolean testBoolean = true;
         final byte testByte = Byte.decode("0x10");
         final byte[] testByteArray = testString.getBytes();
+        final Byte[] testByteArray2 = new Byte[testByteArray.length];
+        for (int currentIndex = 0; currentIndex < testByteArray.length; currentIndex++) {
+            testByteArray2[currentIndex] = testByteArray[currentIndex];
+        }
 
         Assert.assertNotNull(this.userConfigurationDictionary);
 
@@ -123,6 +127,11 @@ public class UserConfigurationDictionaryTest {
         Assert.assertTrue(this.userConfigurationDictionary.containsKey("someByte[]"));
         Assert.assertEquals(testByteArray, this.userConfigurationDictionary.getElements("someByte[]"));
         Assert.assertTrue(this.userConfigurationDictionary.getElements("someByte[]") instanceof byte[]);
+
+        this.userConfigurationDictionary.addElement("someByte2[]", testByteArray2);
+        Assert.assertTrue(this.userConfigurationDictionary.containsKey("someByte2[]"));
+        Assert.assertEquals(testByteArray2, this.userConfigurationDictionary.getElements("someByte2[]"));
+        Assert.assertTrue(this.userConfigurationDictionary.getElements("someByte2[]") instanceof Byte[]);
     }
 
     /**


### PR DESCRIPTION
Details:
- replaced simple casts to instance of checks
- removed unreachable code
- removed handling for unsigned values because in Java, all types are signed
- replaced EwsUtilities.EwsAssert(...) with Exceptions. I think this Method should also be refactored because checking preconditions with java asserts isn't quite a good choice
- imports optimized
