### PR TITLE
Add configurations to make library OSGi compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.microsoft.office</groupId>
     <artifactId>ews-java-api</artifactId>
     <version>1.3-SNAPSHOT</version>
+    <packaging>bundle</packaging>
 
     <name>Exchange Web Services Java API</name>
     <description>Exchange Web Services (EWS) Java API</description>
@@ -68,6 +69,14 @@
     </dependencies>
 
     <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.4.0</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
         <!-- Used to bump all of the various core plugins up to Maven current.
             Use this in conjunction with the versions-maven-plugin to keep your Maven
             plugins up to date. -->


### PR DESCRIPTION
After all, the only things to do was to change the packaging type to bundle and add a plugin which takes care of the correct manifest creation. I checked the created jar before and after my change and everything stayed the same, except for the manifest file.
