### PR TITLE
Issue #109 : use equals() instead of == for String comparison.

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/EwsXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsXmlReader.java
@@ -115,8 +115,8 @@ class EwsXmlReader {
 			this.read(nodeType);
 
 			if ((!this.getLocalName().equals(localName)) ||
-					(this.getNamespaceUri() != EwsUtilities
-							.getNamespaceUri(xmlNamespace))) {
+					(!this.getNamespaceUri().equals(EwsUtilities
+							.getNamespaceUri(xmlNamespace)))) {
 				throw new ServiceXmlDeserializationException(
 						String
 						.format(

--- a/src/main/java/microsoft/exchange/webservices/data/GetStreamingEventsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetStreamingEventsResponse.java
@@ -60,10 +60,10 @@ final class GetStreamingEventsResponse extends ServiceResponse {
 
     	reader.read();
 
-    	if(reader.getLocalName() == XmlElementNames.Notifications) {
+    	if(reader.getLocalName().equals(XmlElementNames.Notifications)) {
     		this.results.loadFromXml(reader);
     	}
-    	else if(reader.getLocalName() == XmlElementNames.ConnectionStatus) {
+    	else if(reader.getLocalName().equals(XmlElementNames.ConnectionStatus)) {
     		String connectionStatus = reader.readElementValue(XmlNamespace. 
     				Messages,XmlElementNames.ConnectionStatus);
 
@@ -89,7 +89,7 @@ final class GetStreamingEventsResponse extends ServiceResponse {
     			reader.read();
 
     			if (reader.getNodeType().getNodeType() == XmlNodeType.START_ELEMENT &&
-    					reader.getLocalName() == XmlElementNames.SubscriptionId) {
+                        reader.getLocalName().equals(XmlElementNames.SubscriptionId)) {
     				this.getErrorSubscriptionIds().add(
     						reader.readElementValue(XmlNamespace.Messages,
     								XmlElementNames.SubscriptionId));

--- a/src/main/java/microsoft/exchange/webservices/data/GetStreamingEventsResults.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetStreamingEventsResults.java
@@ -124,7 +124,7 @@ import java.util.Date;
 
 		reader.read();
 
-		if (reader.getLocalName() == XmlElementNames.FolderId) {
+		if (reader.getLocalName().equals(XmlElementNames.FolderId)) {
 			notificationEvent = new FolderEvent(eventType, timestamp);
 		}
 		else {


### PR DESCRIPTION
Fixes of remaining instances of == operator usage for String comparison.
