### PR TITLE
fix #141 misc.xml

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -10,7 +10,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>


### PR DESCRIPTION
- set project-jdk to level 1.7
- set languageLevel to 1.7
  as in pom.xml specified the project jdk should be 1.7 so the definition of 1.8 was wrong. previously there was also a languageLevel set to jdk1.6 which means that the editor will not suggest java7 specific stuff.
