### PR TITLE
ExtendedPropertyDefinition.isEqualTo method fixed

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/ExtendedPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExtendedPropertyDefinition.java
@@ -206,6 +206,14 @@ public final class ExtendedPropertyDefinition extends PropertyDefinitionBase {
       return false;
     }
 
+    if (extPropDef1.getTag() != null) {
+      if (!extPropDef1.getTag().equals(extPropDef2.getTag())) {
+        return false;
+      }
+    } else if (extPropDef2.getTag() != null) {
+      return false;
+    }
+
     if (extPropDef1.getName() != null) {
       if (!extPropDef1.getName().equals(extPropDef2.getName())) {
         return false;


### PR DESCRIPTION
ExtendedPropertyDefinition.isEqualTo method causes not to update multiple extended properties of an item.
(Caused by the changes at 695d30e83bd93a573aad49567dd44e0ecf7658df)

Tag comparison of extended properties added to fix that problem.
