### PR TITLE
PropertyTag cast error fixed

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/ExtendedPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExtendedPropertyDefinition.java
@@ -315,9 +315,7 @@ public final class ExtendedPropertyDefinition extends PropertyDefinitionBase {
     attributeValue = reader
         .readAttributeValue(XmlAttributeNames.PropertyTag);
     if (null != attributeValue && !attributeValue.isEmpty()) {
-
-      this.tag = Integer.getInteger(attributeValue, 16);
-      //	this.tag = Integer.parseInt(attributeValue, 16);
+      this.tag = Integer.decode(attributeValue);
     }
 
     this.name = reader.readAttributeValue(XmlAttributeNames.PropertyName);


### PR DESCRIPTION
When loading PropertyTag of ExtendedPropertyDefinition from xml, there was hex to integer cast error.

[```Integer.getInteger(attributeValue, 16)```](http://docs.oracle.com/javase/6/docs/api/java/lang/Integer.html#getInteger%28java.lang.String%2C%20int%29) line tries to determine the integer value of the system property with the specified name.
It fails and returns the second parameter as default value.

[```Integer.decode(attributeValue)```](http://docs.oracle.com/javase/6/docs/api/java/lang/Integer.html#decode%28java.lang.String%29) decodes a String into an Integer.
Accepts decimal, hexadecimal, and octal numbers.