### PR TITLE
Fix for AttachmentCollection validate

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/AttachmentCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AttachmentCollection.java
@@ -348,44 +348,37 @@ public final class AttachmentCollection extends
    */
   public void validate() throws Exception {
     // Validate all added attachments
-    boolean contactPhotoFound = false;
-    for (int attachmentIndex = 0; attachmentIndex < this.getAddedItems()
-        .size(); attachmentIndex++) {
-      Attachment attachment = this.getAddedItems().get(attachmentIndex);
-      if (attachment != null && attachment.isNew()) {
-
-        // At the server side, only the last attachment with
-        // IsContactPhoto is kept, all other IsContactPhoto
-        // attachments are removed. CreateAttachment will generate
-        // AttachmentId for each of such attachments (although
-        // only the last one is valid).
-        //
-        // With E14 SP2 CreateItemWithAttachment, such request will only
-        // return 1 AttachmentId; but the client
-        // expects to see all, so let us prevent such "invalid" request
-        // in the first place.
-        //
-        // The IsNew check is to still let CreateAttachmentRequest allow
-        // multiple IsContactPhoto attachments.
-        //
-        if (this.owner.isNew()
-            && this.owner.getService().getRequestedServerVersion()
-            .ordinal() >= ExchangeVersion.Exchange2010_SP2
-            .ordinal()) {
-          if (attachment instanceof FileAttachment) {
-            FileAttachment fileAttachment = (FileAttachment) attachment;
-
-            if (fileAttachment.isContactPhoto()) {
-              if (contactPhotoFound) {
-                throw new ServiceValidationException(
-                    Strings.MultipleContactPhotosInAttachment);
-              }
-
-              contactPhotoFound = true;
+    if (this.owner.isNew()
+        && this.owner.getService().getRequestedServerVersion()
+        .ordinal() >= ExchangeVersion.Exchange2010_SP2
+        .ordinal()) {
+      boolean contactPhotoFound = false;
+      for (int attachmentIndex = 0; attachmentIndex < this.getAddedItems()
+          .size(); attachmentIndex++) {
+        final Attachment attachment = this.getAddedItems().get(attachmentIndex);
+        if (attachment != null && attachment.isNew() && attachment instanceof FileAttachment) {
+          // At the server side, only the last attachment with
+          // IsContactPhoto is kept, all other IsContactPhoto
+          // attachments are removed. CreateAttachment will generate
+          // AttachmentId for each of such attachments (although
+          // only the last one is valid).
+          //
+          // With E14 SP2 CreateItemWithAttachment, such request will only
+          // return 1 AttachmentId; but the client
+          // expects to see all, so let us prevent such "invalid" request
+          // in the first place.
+          //
+          // The IsNew check is to still let CreateAttachmentRequest allow
+          // multiple IsContactPhoto attachments.
+          //
+          if (((FileAttachment) attachment).isContactPhoto()) {
+            if (contactPhotoFound) {
+              throw new ServiceValidationException(
+                  Strings.MultipleContactPhotosInAttachment);
             }
+            contactPhotoFound = true;
           }
         }
-
         attachment.validate(attachmentIndex);
       }
     }

--- a/src/main/java/microsoft/exchange/webservices/data/AttachmentCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AttachmentCollection.java
@@ -352,7 +352,7 @@ public final class AttachmentCollection extends
     for (int attachmentIndex = 0; attachmentIndex < this.getAddedItems()
         .size(); attachmentIndex++) {
       Attachment attachment = this.getAddedItems().get(attachmentIndex);
-      if (attachment.isNew()) {
+      if (attachment != null && attachment.isNew()) {
 
         // At the server side, only the last attachment with
         // IsContactPhoto is kept, all other IsContactPhoto
@@ -372,15 +372,17 @@ public final class AttachmentCollection extends
             && this.owner.getService().getRequestedServerVersion()
             .ordinal() >= ExchangeVersion.Exchange2010_SP2
             .ordinal()) {
-          FileAttachment fileAttachment = (FileAttachment) attachment;
+          if (attachment instanceof FileAttachment) {
+            FileAttachment fileAttachment = (FileAttachment) attachment;
 
-          if (fileAttachment.isContactPhoto()) {
-            if (contactPhotoFound) {
-              throw new ServiceValidationException(
-                  Strings.MultipleContactPhotosInAttachment);
+            if (fileAttachment.isContactPhoto()) {
+              if (contactPhotoFound) {
+                throw new ServiceValidationException(
+                    Strings.MultipleContactPhotosInAttachment);
+              }
+
+              contactPhotoFound = true;
             }
-
-            contactPhotoFound = true;
           }
         }
 


### PR DESCRIPTION
In ```AttachmentCollection.validate()```, type checking added to casting of ```Attachment``` to ```FileAttachment``` as fix for #18.