### PR TITLE
Fix timezone parsing in DateTimeParser with Java 6

### DIFF
--- a/.idea/libraries/Maven__joda_time_joda_time_2_7.xml
+++ b/.idea/libraries/Maven__joda_time_joda_time_2_7.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: joda-time:joda-time:2.7">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/joda-time/joda-time/2.7/joda-time-2.7.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/joda-time/joda-time/2.7/joda-time-2.7-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/joda-time/joda-time/2.7/joda-time-2.7-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/ews-java-api.iml
+++ b/ews-java-api.iml
@@ -14,6 +14,7 @@
     <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.6" level="project" />
     <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.3.3" level="project" />
     <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.2" level="project" />
+    <orderEntry type="library" name="Maven: joda-time:joda-time:2.7" level="project" />
     <orderEntry type="library" name="Maven: jcifs:jcifs:1.3.17" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,12 @@
         </dependency>
 
         <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.7</version>
+        </dependency>
+
+        <dependency>
             <groupId>jcifs</groupId>
             <artifactId>jcifs</artifactId>
             <version>1.3.17</version>

--- a/src/main/java/microsoft/exchange/webservices/data/util/DateTimeParser.java
+++ b/src/main/java/microsoft/exchange/webservices/data/util/DateTimeParser.java
@@ -10,40 +10,27 @@
 
 package microsoft.exchange.webservices.data.util;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
 import java.util.Date;
-import java.util.TimeZone;
 
 public class DateTimeParser {
 
-  private final SimpleDateFormat[] dateTimeFormats = {
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX"),
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX"),
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss"),
-      new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS"),
-      new SimpleDateFormat("yyyy-MM-ddX"),
-      new SimpleDateFormat("yyyy-MM-dd")
+  private final DateTimeFormatter[] dateTimeFormats = {
+      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ").withZoneUTC(),
+      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").withZoneUTC(),
+      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss").withZoneUTC(),
+      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS").withZoneUTC(),
+      DateTimeFormat.forPattern("yyyy-MM-ddZ").withZoneUTC(),
+      DateTimeFormat.forPattern("yyyy-MM-dd").withZoneUTC()
   };
 
-  private final SimpleDateFormat[] dateFormats = {
-      new SimpleDateFormat("yyyy-MM-ddX"),
-      new SimpleDateFormat("yyyy-MM-dd")
+  private final DateTimeFormatter[] dateFormats = {
+      DateTimeFormat.forPattern("yyyy-MM-ddZ").withZoneUTC(),
+      DateTimeFormat.forPattern("yyyy-MM-dd").withZoneUTC()
   };
 
-
-  public DateTimeParser() {
-    // Set default timezone of the formats to UTC, which will be used when the date string doesn't supply a
-    // timezone itself.
-
-    for (SimpleDateFormat format : dateTimeFormats) {
-      format.setTimeZone(TimeZone.getTimeZone("UTC"));
-    }
-
-    for (SimpleDateFormat format : dateFormats) {
-      format.setTimeZone(TimeZone.getTimeZone("UTC"));
-    }
-  }
 
   /**
    * Converts a date time string to local date time.
@@ -85,11 +72,11 @@ public class DateTimeParser {
         value = value.substring(0, value.length() - 1) + "Z";
       }
 
-      SimpleDateFormat[] formats = dateOnly ? dateFormats : dateTimeFormats;
-      for (SimpleDateFormat format : formats) {
+      DateTimeFormatter[] formats = dateOnly ? dateFormats : dateTimeFormats;
+      for (DateTimeFormatter format : formats) {
         try {
-          return format.parse(value);
-        } catch (ParseException e) {
+          return format.parseDateTime(value).toDate();
+        } catch (IllegalArgumentException e) {
           // Ignore and try the next pattern.
         }
       }

--- a/src/test/java/microsoft/exchange/webservices/data/util/DateTimeParserTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/util/DateTimeParserTest.java
@@ -10,7 +10,6 @@
 
 package microsoft.exchange.webservices.data.util;
 
-import microsoft.exchange.webservices.data.util.DateTimeParser;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,6 +21,7 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(JUnit4.class)
 public class DateTimeParserTest {
@@ -36,6 +36,12 @@ public class DateTimeParserTest {
 
 
   // Tests for DateTimeParser.convertDateTimeStringToDate()
+
+  @Test
+  public void testDateTimeEmpty() {
+    assertNull(parser.convertDateTimeStringToDate(null));
+    assertNull(parser.convertDateTimeStringToDate(""));
+  }
 
   @Test
   public void testDateTimeZulu() {
@@ -146,6 +152,12 @@ public class DateTimeParserTest {
 
 
   // Tests for DateTimeParser.convertDateStringToDate()
+
+  @Test
+  public void testDateOnlyEmpty() {
+    assertNull(parser.convertDateStringToDate(null));
+    assertNull(parser.convertDateStringToDate(""));
+  }
 
   @Test
    public void testDateOnlyZulu() {


### PR DESCRIPTION
I have included joda-time as a dependency. It may seem overkill for fixing this issue, but if we do include it now we're able to use it on other places in the future.

Fixes #181.