### PR TITLE
Bad error message of ServiceValidationException

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/PropertySet.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PropertySet.java
@@ -479,7 +479,6 @@ public final class PropertySet implements ISelfValidate,
                 PropertyDefinitionFlags.CanFind, request.
                     getService().getRequestedServerVersion())) {
           throw new ServiceValidationException(String.format(
-              "ServiceValidationException :%s,%s,%s",
               Strings.NonSummaryPropertyCannotBeUsed,
               propertyDefinition.getName(), request
                   .getXmlElementName()));


### PR DESCRIPTION
When it throws ServiceValidationException, '%s' is output to the log.

```
Caused by: microsoft.exchange.webservices.data.ServiceValidationException: ServiceValidationException :The property %s can't be used in %s requests.,null,FindItem
	at microsoft.exchange.webservices.data.PropertySet.validateForRequest(PropertySet.java:481)
	at microsoft.exchange.webservices.data.ViewBase.internalValidate(ViewBase.java:43)
	at microsoft.exchange.webservices.data.PagedView.internalValidate(PagedView.java:104)
	at microsoft.exchange.webservices.data.ItemView.internalValidate(ItemView.java:60)
	at microsoft.exchange.webservices.data.FindRequest.validate(FindRequest.java:64)
	at microsoft.exchange.webservices.data.ServiceRequestBase.validateAndEmitRequest(ServiceRequestBase.java:621)
	at microsoft.exchange.webservices.data.SimpleServiceRequestBase.internalExecute(SimpleServiceRequestBase.java:46)
	... 93 more
```