### PR TITLE
Deploy artifacts to maven central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.microsoft.office</groupId>
+    <groupId>com.microsoft.ewsjavaapi</groupId>
     <artifactId>ews-java-api</artifactId>
     <version>1.3-SNAPSHOT</version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.microsoft.ewsjavaapi</groupId>
     <artifactId>ews-java-api</artifactId>
     
-    <version>1.3-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
 
     <name>Exchange Web Services Java API</name>
     <description>Exchange Web Services (EWS) Java API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,7 @@
 
     <groupId>com.microsoft.ewsjavaapi</groupId>
     <artifactId>ews-java-api</artifactId>
+    
     <version>1.3-SNAPSHOT</version>
 
     <name>Exchange Web Services Java API</name>
@@ -59,6 +60,17 @@
         <developerConnection>scm:git:ssh://git@github.com:OfficeDev/ews-java-api.git</developerConnection>
     </scm>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+        </repository>
+    </distributionManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -101,7 +113,17 @@
 
     <build>
         <plugins>
-            <!--Deployment / build plugins-->
+            <!-- Deployment / build plugins -->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.5</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <!-- Ref.: http://books.sonatype.com/nexus-book/reference/staging-deployment.html -->
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -137,7 +159,7 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--Deployment / build plugins END-->
+            <!-- Deployment / build plugins END -->
         </plugins>
         <!-- Used to bump all of the various core plugins up to Maven current.
             Use this in conjunction with the versions-maven-plugin to keep your Maven

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,30 @@
         <javaLanguage.version>1.6</javaLanguage.version>
     </properties>
 
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <issueManagement>
+        <url>https://github.com/OfficeDev/ews-java-api/issues</url>
+        <system>GitHub Issues</system>
+    </issueManagement>
+
+    <ciManagement>
+        <system>travis</system>
+        <url>https://travis-ci.org/OfficeDev/ews-java-api</url>
+    </ciManagement>
+
+    <scm>
+        <url>https://github.com/OfficeDev/ews-java-api</url>
+        <connection>scm:git:ssh://git@github.com:OfficeDev/ews-java-api.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:OfficeDev/ews-java-api.git</developerConnection>
+    </scm>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -77,6 +101,7 @@
 
     <build>
         <plugins>
+            <!--Deployment / build plugins-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -86,6 +111,33 @@
                     <target>${javaLanguage.version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!--Deployment / build plugins END-->
         </plugins>
         <!-- Used to bump all of the various core plugins up to Maven current.
             Use this in conjunction with the versions-maven-plugin to keep your Maven
@@ -132,7 +184,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>2.10.1</version>
                 <configuration>
                     <linksource>true</linksource>
                 </configuration>

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,10 @@
 
 # Getting Started with the EWS JAVA API
 
+## Building EWS JAVA API
+To build your own jar you will need to download and [install maven](http://maven.apache.org/guides/getting-started/maven-in-five-minutes.html).
+After the installation you can navigate to your local repository via cmd and run `mvn clean install`. This will validate the available unit-tests und build all necessary jars which afterwards may be found @ `PROJECT_ROOT\target`.
+
 ## Using the EWS JAVA API for https
 
 To make an environment secure, you must be sure that any communication is with "trusted" sites. SSL uses certificates for authentication — these are digitally signed documents that bind the public key to the identity of the private key owner.


### PR DESCRIPTION
This PR is about Issue: #1. But also adds inprovements for building a local Jar-File.
We are able to create Jars easily now `mvn clean install` provides 3 jars now (`PROJECT_ROOT\target`):
* ews-java-api-1.3-SNAPSHOT.jar
* ews-java-api-1.3-SNAPSHOT-javadoc.jar
* ews-java-api-1.3-SNAPSHOT-sources.jar

I also added the ability for deploying to sonatype by integrating `nexus-staging-maven-plugin`.
`mvn clean deploy` will now publish jars to sonatype if valid credentials are stored in settings.xml (just tested until the upload cause I dont have the credentials). If the release-name end with snapshot it will automaticly been stored to snapshot repo.

settings.xml (`~/.m2/settings.xml`) should look like this:
```xml
<settings>
  ...
  <servers>
    ...
    <server>
      <id>ossrh</id> <!-- ref to id in pom.xml / distributionManagement --> 
      <username>Jira username</username>
      <password>Jira password</password>
    </server>
  </servers>
  ...
</settings>
```
The password should be stored [encrypted](http://maven.apache.org/guides/mini/guide-encryption.html).