### PR TITLE
Building against multiple jdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: java
 
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk6
+
 notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/04643d955d03eb39e24e
-    on_success: change  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: false     # default: false
+    on_success: change

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,21 @@
             should probably be UTF-8 nowadays. -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javaLanguage.version>1.6</javaLanguage.version>
+        <javadoc.doclint.param/>
     </properties>
+
+    <profiles>
+        <profile>
+            <!-- handle broken builds on jdk1.8 due to doclint function -->
+            <id>default-jdk18-profile</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <javadoc.doclint.param>-Xdoclint:none</javadoc.doclint.param>
+            </properties>
+        </profile>
+    </profiles>
 
     <dependencies>
         <dependency>
@@ -80,6 +94,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <source>${javaLanguage.version}</source>
@@ -135,6 +150,7 @@
                 <version>2.9.1</version>
                 <configuration>
                     <linksource>true</linksource>
+                    <additionalparam>${javadoc.doclint.param}</additionalparam>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
As mentioned in #181 we ran into issues because there where differences in the used jdk. This PR tries to prevent this in the future by adding maven profiles for travis-ci which will now build the api against all available jdk's. This also prevents the build from failing while compiling with jdk1.8 with enabled doclint function.