### PR TITLE
fix: Issue 28 and add improvement for response parameters

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/DelegateManagementRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DelegateManagementRequestBase.java
@@ -27,9 +27,8 @@ package microsoft.exchange.webservices.data;
  *
  * @param <TResponse> The type of the response.
  */
-abstract class DelegateManagementRequestBase
-    <TResponse extends DelegateManagementResponse>
-    extends SimpleServiceRequestBase {
+abstract class DelegateManagementRequestBase<TResponse extends DelegateManagementResponse>
+    extends SimpleServiceRequestBase<TResponse> {
 
   /**
    * The mailbox.
@@ -80,16 +79,12 @@ abstract class DelegateManagementRequestBase
   protected abstract TResponse createResponse();
 
   /**
-   * Parses the response.
-   *
-   * @param reader the reader
-   * @return Response object.
-   * @throws Exception the exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected TResponse parseResponse(EwsServiceXmlReader reader)
       throws Exception {
-    DelegateManagementResponse response = this.createResponse();
+    TResponse response = this.createResponse();
     response.loadFromXml(reader, this.getResponseXmlElementName());
     return response;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/DisconnectPhoneCallRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DisconnectPhoneCallRequest.java
@@ -25,7 +25,7 @@ package microsoft.exchange.webservices.data;
 /**
  * Represents a DisconnectPhoneCall request.
  */
-final class DisconnectPhoneCallRequest extends SimpleServiceRequestBase {
+final class DisconnectPhoneCallRequest extends SimpleServiceRequestBase<ServiceResponse> {
 
   /**
    * The id.
@@ -77,14 +77,10 @@ final class DisconnectPhoneCallRequest extends SimpleServiceRequestBase {
   }
 
   /**
-   * Parses the response.
-   *
-   * @param reader the reader
-   * @return Response object.
-   * @throws Exception the exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected ServiceResponse parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     ServiceResponse serviceResponse = new ServiceResponse();
     serviceResponse.loadFromXml(reader,

--- a/src/main/java/microsoft/exchange/webservices/data/FindConversationRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FindConversationRequest.java
@@ -25,7 +25,7 @@ package microsoft.exchange.webservices.data;
 /**
  * Represents a request to a Find Conversation operation
  */
-final class FindConversationRequest extends SimpleServiceRequestBase {
+final class FindConversationRequest extends SimpleServiceRequestBase<FindConversationResponse> {
 
 
   private ConversationIndexedItemView view;
@@ -132,14 +132,10 @@ final class FindConversationRequest extends SimpleServiceRequestBase {
   }
 
   /**
-   * Parses the response.
-   *
-   * @param reader The reader.
-   * @return Response object.
-   * @throws Exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected FindConversationResponse parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     FindConversationResponse response = new FindConversationResponse();
     response.loadFromXml(reader,

--- a/src/main/java/microsoft/exchange/webservices/data/GetInboxRulesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetInboxRulesRequest.java
@@ -27,7 +27,7 @@ import javax.xml.stream.XMLStreamException;
 /**
  * Represents a GetInboxRules request.
  */
-final class GetInboxRulesRequest extends SimpleServiceRequestBase {
+final class GetInboxRulesRequest extends SimpleServiceRequestBase<GetInboxRulesResponse> {
 
   /**
    * The smtp address of the mailbox from which to get the inbox rules.
@@ -101,14 +101,10 @@ final class GetInboxRulesRequest extends SimpleServiceRequestBase {
   }
 
   /**
-   * Parses the response.
-   *
-   * @param reader The reader.
-   * @return Response object.
-   * @throws Exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected GetInboxRulesResponse parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     GetInboxRulesResponse response = new GetInboxRulesResponse();
     response.loadFromXml(reader, XmlElementNames.GetInboxRulesResponse);

--- a/src/main/java/microsoft/exchange/webservices/data/GetPasswordExpirationDateRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetPasswordExpirationDateRequest.java
@@ -24,7 +24,7 @@ package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;
 
-public final class GetPasswordExpirationDateRequest extends SimpleServiceRequestBase {
+public final class GetPasswordExpirationDateRequest extends SimpleServiceRequestBase<GetPasswordExpirationDateResponse> {
 
   @Override
   protected ExchangeVersion getMinimumRequiredServerVersion() {
@@ -64,15 +64,13 @@ public final class GetPasswordExpirationDateRequest extends SimpleServiceRequest
   }
 
   /**
-   * Parses the response
-   *
-   * @return GEtPasswordExpirationDateResponse
+   * {@inheritDoc}
    */
-  protected Object parseResponse(EwsServiceXmlReader reader) throws Exception {
+  @Override
+  protected GetPasswordExpirationDateResponse parseResponse(EwsServiceXmlReader reader) throws Exception {
     GetPasswordExpirationDateResponse response = new GetPasswordExpirationDateResponse();
     response.loadFromXml(reader, XmlElementNames.GetPasswordExpirationDateResponse);
     return response;
-
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetPhoneCallRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetPhoneCallRequest.java
@@ -25,7 +25,7 @@ package microsoft.exchange.webservices.data;
 /**
  * Represents a GetPhoneCall request.
  */
-final class GetPhoneCallRequest extends SimpleServiceRequestBase {
+final class GetPhoneCallRequest extends SimpleServiceRequestBase<GetPhoneCallResponse> {
 
   /**
    * The id.
@@ -77,14 +77,10 @@ final class GetPhoneCallRequest extends SimpleServiceRequestBase {
   }
 
   /**
-   * Parses the response.
-   *
-   * @param reader the reader
-   * @return Response object.
-   * @throws Exception the exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected GetPhoneCallResponse parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     GetPhoneCallResponse response = new GetPhoneCallResponse(getService());
     response.loadFromXml(reader, XmlElementNames.GetPhoneCallResponse);

--- a/src/main/java/microsoft/exchange/webservices/data/GetRoomListsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetRoomListsRequest.java
@@ -25,7 +25,7 @@ package microsoft.exchange.webservices.data;
 /**
  * Represents a GetRoomList request.
  */
-final class GetRoomListsRequest extends SimpleServiceRequestBase {
+final class GetRoomListsRequest extends SimpleServiceRequestBase<GetRoomListsResponse> {
 
   /**
    * Initializes a new instance of the class.
@@ -69,14 +69,10 @@ final class GetRoomListsRequest extends SimpleServiceRequestBase {
   }
 
   /**
-   * Parses the response.
-   *
-   * @param reader the reader
-   * @return Response object.
-   * @throws Exception the exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected GetRoomListsResponse parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     GetRoomListsResponse response = new GetRoomListsResponse();
     response.loadFromXml(reader, XmlElementNames.GetRoomListsResponse);

--- a/src/main/java/microsoft/exchange/webservices/data/GetRoomsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetRoomsRequest.java
@@ -25,7 +25,7 @@ package microsoft.exchange.webservices.data;
 /**
  * Represents a GetRooms request.
  */
-final class GetRoomsRequest extends SimpleServiceRequestBase {
+final class GetRoomsRequest extends SimpleServiceRequestBase<GetRoomsResponse> {
 
   /**
    * Represents a GetRooms request.
@@ -72,14 +72,10 @@ final class GetRoomsRequest extends SimpleServiceRequestBase {
   }
 
   /**
-   * Parses the response.
-   *
-   * @param reader the reader
-   * @return Response object.
-   * @throws Exception the exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected GetRoomsResponse parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     GetRoomsResponse response = new GetRoomsResponse();
     response.loadFromXml(reader, XmlElementNames.GetRoomsResponse);

--- a/src/main/java/microsoft/exchange/webservices/data/GetStreamingEventsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetStreamingEventsRequest.java
@@ -27,7 +27,7 @@ import javax.xml.stream.XMLStreamException;
 /**
  * Defines the GetStreamingEventsRequest class.
  */
-class GetStreamingEventsRequest extends HangingServiceRequestBase {
+class GetStreamingEventsRequest extends HangingServiceRequestBase<GetStreamingEventsResponse> {
 
   protected final static int HeartbeatFrequencyDefault = 45000; ////45s in ms
   private static int heartbeatFrequency = HeartbeatFrequencyDefault;
@@ -113,14 +113,10 @@ class GetStreamingEventsRequest extends HangingServiceRequestBase {
   }
 
   /**
-   * Parses the response.
-   *
-   * @param reader The reader
-   * @return response
-   * @throws Exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected GetStreamingEventsResponse parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     reader.readStartElement(XmlNamespace.Messages,
         XmlElementNames.ResponseMessages);

--- a/src/main/java/microsoft/exchange/webservices/data/GetUserAvailabilityRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetUserAvailabilityRequest.java
@@ -25,7 +25,7 @@ package microsoft.exchange.webservices.data;
 /**
  * Represents a GetUserAvailability request.
  */
-final class GetUserAvailabilityRequest extends SimpleServiceRequestBase {
+final class GetUserAvailabilityRequest extends SimpleServiceRequestBase<GetUserAvailabilityResults> {
 
   /**
    * The attendees.
@@ -147,14 +147,10 @@ final class GetUserAvailabilityRequest extends SimpleServiceRequestBase {
   }
 
   /**
-   * Parses the response.
-   *
-   * @param reader the reader
-   * @return Response object.
-   * @throws Exception the exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected GetUserAvailabilityResults parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     GetUserAvailabilityResults serviceResponse =
         new GetUserAvailabilityResults();

--- a/src/main/java/microsoft/exchange/webservices/data/GetUserOofSettingsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetUserOofSettingsRequest.java
@@ -27,7 +27,7 @@ import javax.xml.stream.XMLStreamException;
 /**
  * Represents a GetUserOofSettings request.
  */
-final class GetUserOofSettingsRequest extends SimpleServiceRequestBase {
+final class GetUserOofSettingsRequest extends SimpleServiceRequestBase<GetUserOofSettingsResponse> {
 
   /**
    * The smtp address.
@@ -83,14 +83,10 @@ final class GetUserOofSettingsRequest extends SimpleServiceRequestBase {
   }
 
   /**
-   * Parses the response.
-   *
-   * @param reader the reader
-   * @return Response object
-   * @throws Exception the exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected GetUserOofSettingsResponse parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     GetUserOofSettingsResponse serviceResponse =
         new GetUserOofSettingsResponse();

--- a/src/main/java/microsoft/exchange/webservices/data/HangingServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/HangingServiceRequestBase.java
@@ -128,7 +128,7 @@ class HangingRequestDisconnectEventArgs {
 /**
  * Represents an abstract, hanging service request.
  */
-abstract class HangingServiceRequestBase extends ServiceRequestBase {
+abstract class HangingServiceRequestBase<T> extends ServiceRequestBase<T> {
 
   protected interface IHandleResponseObject {
 
@@ -251,9 +251,8 @@ abstract class HangingServiceRequestBase extends ServiceRequestBase {
   /**
    * Parses the responses.
    *
-   * @param state The state.
    */
-  private void parseResponses(Object state) {
+  private void parseResponses() {
     HangingTraceStream tracingStream = null;
     ByteArrayOutputStream responseCopy = null;
 
@@ -275,7 +274,7 @@ abstract class HangingServiceRequestBase extends ServiceRequestBase {
 
 
       while (this.isConnected()) {
-        Object responseObject = null;
+        T responseObject = null;
         if (traceEWSResponse) {
                                         /*try{*/
           EwsServiceMultiResponseXmlReader ewsXmlReader =
@@ -413,7 +412,7 @@ abstract class HangingServiceRequestBase extends ServiceRequestBase {
           keepAliveTime, TimeUnit.SECONDS, queue);
       threadPool.execute(new Runnable() {
         public void run() {
-          parseResponses(null);
+          parseResponses();
         }
       });
       threadPool.shutdown();

--- a/src/main/java/microsoft/exchange/webservices/data/MultiResponseServiceRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MultiResponseServiceRequest.java
@@ -28,7 +28,7 @@ package microsoft.exchange.webservices.data;
  * @param <TResponse> The type of the response.
  */
 abstract class MultiResponseServiceRequest<TResponse extends ServiceResponse>
-    extends SimpleServiceRequestBase {
+    extends SimpleServiceRequestBase<ServiceResponseCollection<TResponse>> {
 
   /**
    * The error handling mode.
@@ -36,14 +36,10 @@ abstract class MultiResponseServiceRequest<TResponse extends ServiceResponse>
   private ServiceErrorHandling errorHandlingMode;
 
   /**
-   * Parses the response.
-   *
-   * @param reader The reader.
-   * @return Response object.
-   * @throws Exception the exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected ServiceResponseCollection<TResponse> parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     ServiceResponseCollection<TResponse> serviceResponses =
         new ServiceResponseCollection<TResponse>();

--- a/src/main/java/microsoft/exchange/webservices/data/PlayOnPhoneRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PlayOnPhoneRequest.java
@@ -25,7 +25,7 @@ package microsoft.exchange.webservices.data;
 /**
  * Represents a PlayOnPhone request.
  */
-final class PlayOnPhoneRequest extends SimpleServiceRequestBase {
+final class PlayOnPhoneRequest extends SimpleServiceRequestBase<PlayOnPhoneResponse> {
 
   /**
    * The item id.
@@ -84,14 +84,10 @@ final class PlayOnPhoneRequest extends SimpleServiceRequestBase {
   }
 
   /**
-   * Parses the response.
-   *
-   * @param reader the reader
-   * @return Response object.
-   * @throws Exception the exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected PlayOnPhoneResponse parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     PlayOnPhoneResponse serviceResponse = new PlayOnPhoneResponse(this
         .getService());

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceRequestBase.java
@@ -394,13 +394,11 @@ abstract class ServiceRequestBase<T> {
         ByteArrayOutputStream memoryStream = new ByteArrayOutputStream();
         InputStream serviceResponseStream = ServiceRequestBase
             .getResponseStream(response);
-        while (true) {
-          int data = serviceResponseStream.read();
-          if (-1 == data) {
-            break;
-          } else {
+
+        int data = serviceResponseStream.read();
+        while (data != -1) {
             memoryStream.write(data);
-          }
+            data = serviceResponseStream.read();
         }
 
         this.traceResponse(response, memoryStream);

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceRequestBase.java
@@ -417,28 +417,24 @@ abstract class ServiceRequestBase<T> {
         EwsServiceXmlReader ewsXmlReader = new EwsServiceXmlReader(
             responseStream, this.getService());
         serviceResponse = this.readResponse(ewsXmlReader);
-
       }
+
+      return serviceResponse;
     } catch (HTTPException e) {
       if (e.getMessage() != null) {
         this.getService().processHttpResponseHeaders(
             TraceFlags.EwsResponseHttpHeaders, response);
       }
-
       throw new ServiceRequestException(String.format(
           Strings.ServiceRequestFailed, e.getMessage()), e);
     } catch (IOException e) {
-      // Wrap exception.
       throw new ServiceRequestException(String.format(
           Strings.ServiceRequestFailed, e.getMessage()), e);
-    } finally {
+    } finally { // close the underlying response
       if (response != null) {
         response.close();
       }
     }
-
-    return serviceResponse;
-
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/SetUserOofSettingsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SetUserOofSettingsRequest.java
@@ -25,7 +25,7 @@ package microsoft.exchange.webservices.data;
 /**
  * Represents a SetUserOofSettings request.
  */
-final class SetUserOofSettingsRequest extends SimpleServiceRequestBase {
+final class SetUserOofSettingsRequest extends SimpleServiceRequestBase<ServiceResponse> {
 
   /**
    * The smtp address.
@@ -89,14 +89,10 @@ final class SetUserOofSettingsRequest extends SimpleServiceRequestBase {
   }
 
   /**
-   * Parses the response.
-   *
-   * @param reader the reader
-   * @return Service response
-   * @throws Exception the exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected ServiceResponse parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     ServiceResponse serviceResponse = new ServiceResponse();
     serviceResponse.loadFromXml(reader, XmlElementNames.ResponseMessage);

--- a/src/main/java/microsoft/exchange/webservices/data/SimpleServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SimpleServiceRequestBase.java
@@ -68,14 +68,6 @@ abstract class SimpleServiceRequestBase<T> extends ServiceRequestBase<T> {
       }
 
       throw new ServiceRequestException(String.format(Strings.ServiceRequestFailed, e.getMessage()), e);
-    } finally {
-      try {
-        if (response != null) {
-          response.close();
-        }
-      } catch (Exception e2) {
-        response = null;
-      }
     }
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/SimpleServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SimpleServiceRequestBase.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Future;
 /**
  * Defines the SimpleServiceRequestBase class.
  */
-abstract class SimpleServiceRequestBase extends ServiceRequestBase {
+abstract class SimpleServiceRequestBase<T> extends ServiceRequestBase<T> {
 
   private static final Log log = LogFactory.getLog(SimpleServiceRequestBase.class);
 
@@ -51,7 +51,7 @@ abstract class SimpleServiceRequestBase extends ServiceRequestBase {
    * @throws Exception
    * @throws microsoft.exchange.webservices.data.ServiceLocalException
    */
-  protected Object internalExecute() throws ServiceLocalException, Exception {
+  protected T internalExecute() throws ServiceLocalException, Exception {
     HttpWebRequest response = null;
 
     try {
@@ -85,7 +85,7 @@ abstract class SimpleServiceRequestBase extends ServiceRequestBase {
    * @param asyncResult The async result
    * @return Service response object.
    */
-  protected Object endInternalExecute(IAsyncResult asyncResult) throws Exception {
+  protected T endInternalExecute(IAsyncResult asyncResult) throws Exception {
     HttpWebRequest response = (HttpWebRequest) asyncResult.get();
     return this.readResponse(response);
   }
@@ -119,82 +119,4 @@ abstract class SimpleServiceRequestBase extends ServiceRequestBase {
     // return new AsyncRequestResult(this, request, webAsyncResult, state /*
     // user state */);
   }
-
-  /**
-   * Reads the response.
-   *
-   * @return serviceResponse
-   * @throws Exception
-   */
-  private Object readResponse(HttpWebRequest response) throws Exception {
-    Object serviceResponse;
-
-    if (!response.getResponseContentType().startsWith("text/xml")) {
-      String line = new BufferedReader(new InputStreamReader(ServiceRequestBase.getResponseStream(response)))
-          .readLine();
-      log.error("Response content type not XML; first line: '" + line + "'");
-      throw new ServiceRequestException(Strings.ServiceResponseDoesNotContainXml);
-    }
-
-    /**
-     * If tracing is enabled, we read the entire response into a
-     * MemoryStream so that we can pass it along to the ITraceListener. Then
-     * we parse the response from the MemoryStream.
-     */
-
-    try {
-      this.getService().processHttpResponseHeaders(
-          TraceFlags.EwsResponseHttpHeaders, response);
-
-      if (this.getService().isTraceEnabledFor(TraceFlags.EwsResponse)) {
-        ByteArrayOutputStream memoryStream = new ByteArrayOutputStream();
-        InputStream serviceResponseStream = ServiceRequestBase
-            .getResponseStream(response);
-        while (true) {
-          int data = serviceResponseStream.read();
-          if (-1 == data) {
-            break;
-          } else {
-            memoryStream.write(data);
-          }
-        }
-
-        this.traceResponse(response, memoryStream);
-        ByteArrayInputStream memoryStreamIn = new ByteArrayInputStream(
-            memoryStream.toByteArray());
-        EwsServiceXmlReader ewsXmlReader = new EwsServiceXmlReader(
-            memoryStreamIn, this.getService());
-        serviceResponse = this.readResponse(ewsXmlReader);
-        serviceResponseStream.close();
-        memoryStream.flush();
-      } else {
-        InputStream responseStream = ServiceRequestBase
-            .getResponseStream(response);
-        EwsServiceXmlReader ewsXmlReader = new EwsServiceXmlReader(
-            responseStream, this.getService());
-        serviceResponse = this.readResponse(ewsXmlReader);
-
-      }
-    } catch (HTTPException e) {
-      if (e.getMessage() != null) {
-        this.getService().processHttpResponseHeaders(
-            TraceFlags.EwsResponseHttpHeaders, response);
-      }
-
-      throw new ServiceRequestException(String.format(
-          Strings.ServiceRequestFailed, e.getMessage()), e);
-    } catch (IOException e) {
-      // Wrap exception.
-      throw new ServiceRequestException(String.format(
-          Strings.ServiceRequestFailed, e.getMessage()), e);
-    } finally {
-      if (response != null) {
-        response.close();
-      }
-    }
-
-    return serviceResponse;
-
-  }
-
 }

--- a/src/main/java/microsoft/exchange/webservices/data/UpdateInboxRulesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UpdateInboxRulesRequest.java
@@ -25,7 +25,7 @@ package microsoft.exchange.webservices.data;
 /**
  * Represents a UpdateInboxRulesRequest request.
  */
-final class UpdateInboxRulesRequest extends SimpleServiceRequestBase {
+final class UpdateInboxRulesRequest extends SimpleServiceRequestBase<UpdateInboxRulesResponse> {
   /**
    * The smtp address of the mailbox from which to get the inbox rules.
    */
@@ -100,14 +100,10 @@ final class UpdateInboxRulesRequest extends SimpleServiceRequestBase {
   }
 
   /**
-   * Parses the response.
-   *
-   * @param reader The reader.
-   * @return Response object.
-   * @throws Exception
+   * {@inheritDoc}
    */
   @Override
-  protected Object parseResponse(EwsServiceXmlReader reader)
+  protected UpdateInboxRulesResponse parseResponse(EwsServiceXmlReader reader)
       throws Exception {
     UpdateInboxRulesResponse response = new UpdateInboxRulesResponse();
     response.loadFromXml(reader, XmlElementNames.UpdateInboxRulesResponse);


### PR DESCRIPTION
This PR will fix issue 28 which outlined that the response-object from an internalExecute will be closed twice which will result in an error. I also tried to add some improvement to the handling of return-parameters as well since they where just defined as Object and dont include reflection. 

This should not be merged since the functionality of the methods changed is confirmed.
Therefore help with testing would be welcome as well as your comments and suggestions.