### PR TITLE
Added more date-patterns and a test to resolve the milliseconds issue

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/util/DateTimeParser.java
+++ b/src/main/java/microsoft/exchange/webservices/data/util/DateTimeParser.java
@@ -10,18 +10,20 @@
 
 package microsoft.exchange.webservices.data.util;
 
+import java.util.Date;
+
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
-
-import java.util.Date;
 
 public class DateTimeParser {
 
   private final DateTimeFormatter[] dateTimeFormats = {
       DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ").withZoneUTC(),
       DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").withZoneUTC(),
+      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ").withZoneUTC(),
       DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss").withZoneUTC(),
       DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS").withZoneUTC(),
+      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSS").withZoneUTC(),
       DateTimeFormat.forPattern("yyyy-MM-ddZ").withZoneUTC(),
       DateTimeFormat.forPattern("yyyy-MM-dd").withZoneUTC()
   };

--- a/src/test/java/microsoft/exchange/webservices/data/util/DateTimeParserTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/util/DateTimeParserTest.java
@@ -86,6 +86,20 @@ public class DateTimeParserTest {
   }
 
   @Test
+  public void testDateTimeZuluWithMilliseconds() {
+    String dateString = "9999-12-30T23:59:59.9999999Z";
+    Date parsed = parser.convertDateTimeStringToDate(dateString);
+    Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+    calendar.setTime(parsed);
+    assertEquals(9999, calendar.get(Calendar.YEAR));
+    assertEquals(11, calendar.get(Calendar.MONTH));
+    assertEquals(30, calendar.get(Calendar.DATE));
+    assertEquals(23, calendar.get(Calendar.HOUR_OF_DAY));
+    assertEquals(59, calendar.get(Calendar.MINUTE));
+    assertEquals(59, calendar.get(Calendar.SECOND));
+  }
+
+  @Test
    public void testDateTimeWithTimeZone() {
     String dateString = "2015-01-08T10:11:12+0200";
     Date parsed = parser.convertDateTimeStringToDate(dateString);


### PR DESCRIPTION
Even though the example in #206 is a bit special (max-date?) the pattern can be supported. Added datePattern and a test.