### PR TITLE
exchange2007CompatibilityMode flag is now taken into account to create t...

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExchangeService.java
@@ -3826,21 +3826,29 @@ public final class ExchangeService extends ExchangeServiceBase implements
     return this.enableScpLookup;
   }
 
+
   public void setEnableScpLookup(boolean value) {
     this.enableScpLookup = value;
   }
 
   /**
-   * Gets or sets a value indicating whether Exchange2007 compatibility mode
-   * is enabled. <remarks> In order to support E12 servers, the
-   * Exchange2007CompatibilityMode property can be used to indicate that we
-   * should use "Exchange2007" as the server version String rather than
-   * Exchange2007_SP1. </remarks>
+   * Returns true whether Exchange2007 compatibility mode is enabled, false otherwise.
    */
   public boolean getExchange2007CompatibilityMode() {
     return this.exchange2007CompatibilityMode;
   }
 
+  /**
+   * Set the flag indicating if the Exchange2007 compatibility mode is enabled.
+   *
+   * <remarks>
+   * In order to support E12 servers, the <code>exchange2007CompatibilityMode</code> property,
+   * set to true, can be used to indicate that we should use "Exchange2007" as the server version String
+   * rather than Exchange2007_SP1.
+   * </remarks>
+   *
+   * @param value true if the Exchange2007 compatibility mode is enabled.
+   */
   public void setExchange2007CompatibilityMode(boolean value) {
     this.exchange2007CompatibilityMode = value;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExchangeService.java
@@ -65,10 +65,14 @@ public final class ExchangeService extends ExchangeServiceBase implements
    */
   private UnifiedMessaging unifiedMessaging;
 
-  // private boolean exchange2007CompatibilityMode;
   private boolean enableScpLookup = true;
 
-  private boolean exchange2007CompatibilityMode;
+  /**
+   * When false, used to indicate that we should use "Exchange2007" as the server version String rather than
+   * Exchange2007_SP1 (@see #getExchange2007CompatibilityMode).
+   *
+   */
+  private boolean exchange2007CompatibilityMode = false;
 
   /**
    * Create response object.
@@ -3833,11 +3837,11 @@ public final class ExchangeService extends ExchangeServiceBase implements
    * should use "Exchange2007" as the server version String rather than
    * Exchange2007_SP1. </remarks>
    */
-  protected boolean getExchange2007CompatibilityMode() {
+  public boolean getExchange2007CompatibilityMode() {
     return this.exchange2007CompatibilityMode;
   }
 
-  protected void setExchange2007CompatibilityMode(boolean value) {
+  public void setExchange2007CompatibilityMode(boolean value) {
     this.exchange2007CompatibilityMode = value;
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceRequestBase.java
@@ -285,7 +285,7 @@ abstract class ServiceRequestBase {
    * @return String representation of requested server version.
    */
   private String getRequestedServiceVersionString() {
-    if (this.service.getRequestedServerVersion() == ExchangeVersion.Exchange2007_SP1) {
+    if (this.service.getRequestedServerVersion() == ExchangeVersion.Exchange2007_SP1 && this.service.getExchange2007CompatibilityMode()) {
       return "Exchange2007";
     } else {
       return this.service.getRequestedServerVersion().toString();


### PR DESCRIPTION
...he request SOAP version header. Previously a Exchange2007_SP1 version was always sent as Exchange2007 (with potential problem like no access to PublicFoldersRoot). Now behaviour can be decided than to the flag.