### PR TITLE
license-header with checkstyle google-style

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/AbsoluteDateTransition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AbsoluteDateTransition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/AbsoluteDayOfMonthTransition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AbsoluteDayOfMonthTransition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/AbsoluteMonthTransition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AbsoluteMonthTransition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/AbstractAsyncCallback.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AbstractAsyncCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.concurrent.Future;

--- a/src/main/java/microsoft/exchange/webservices/data/AbstractFolderIdWrapper.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AbstractFolderIdWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AbstractItemIdWrapper.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AbstractItemIdWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AcceptMeetingInvitationMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AcceptMeetingInvitationMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AccountIsLockedException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AccountIsLockedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.net.URI;

--- a/src/main/java/microsoft/exchange/webservices/data/AddDelegateRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AddDelegateRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/AffectedTaskOccurrence.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AffectedTaskOccurrence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AggregateType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AggregateType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AlternateId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AlternateId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AlternateIdBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AlternateIdBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/AlternateMailbox.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AlternateMailbox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AlternateMailboxCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AlternateMailboxCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/AlternatePublicFolderId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AlternatePublicFolderId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AlternatePublicFolderItemId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AlternatePublicFolderItemId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ApplyConversationActionRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ApplyConversationActionRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/Appointment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Appointment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/AppointmentOccurrenceId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AppointmentOccurrenceId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AppointmentSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AppointmentSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/AppointmentType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AppointmentType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ArgumentException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ArgumentException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ArgumentNullException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ArgumentNullException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ArgumentOutOfRangeException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ArgumentOutOfRangeException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AsyncCallback.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AsyncCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.concurrent.Future;

--- a/src/main/java/microsoft/exchange/webservices/data/AsyncCallbackImplementation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AsyncCallbackImplementation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.concurrent.Future;

--- a/src/main/java/microsoft/exchange/webservices/data/AsyncExecutor.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AsyncExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.concurrent.*;

--- a/src/main/java/microsoft/exchange/webservices/data/AsyncRequestResult.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AsyncRequestResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.concurrent.*;

--- a/src/main/java/microsoft/exchange/webservices/data/Attachable.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Attachable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/microsoft/exchange/webservices/data/Attachment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Attachment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/AttachmentCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AttachmentCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.io.File;

--- a/src/main/java/microsoft/exchange/webservices/data/AttachmentsPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AttachmentsPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/Attendee.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Attendee.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/AttendeeAvailability.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AttendeeAvailability.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/AttendeeCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AttendeeCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AttendeeInfo.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AttendeeInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AutodiscoverDnsClient.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AutodiscoverDnsClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/AutodiscoverEndpoints.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AutodiscoverEndpoints.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AutodiscoverError.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AutodiscoverError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AutodiscoverErrorCode.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AutodiscoverErrorCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AutodiscoverLocalException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AutodiscoverLocalException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AutodiscoverRemoteException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AutodiscoverRemoteException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AutodiscoverRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AutodiscoverRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/AutodiscoverResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AutodiscoverResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.net.URI;

--- a/src/main/java/microsoft/exchange/webservices/data/AutodiscoverResponseCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AutodiscoverResponseCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/AutodiscoverResponseException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AutodiscoverResponseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AutodiscoverResponseType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AutodiscoverResponseType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AutodiscoverService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.apache.commons.logging.Log;

--- a/src/main/java/microsoft/exchange/webservices/data/AvailabilityData.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AvailabilityData.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/AvailabilityOptions.java
+++ b/src/main/java/microsoft/exchange/webservices/data/AvailabilityOptions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/Base64.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Base64.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Base64EncoderStream.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Base64EncoderStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Vector;

--- a/src/main/java/microsoft/exchange/webservices/data/BasePropertySet.java
+++ b/src/main/java/microsoft/exchange/webservices/data/BasePropertySet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/BodyType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/BodyType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/BoolPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/BoolPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/ByteArrayArray.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ByteArrayArray.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ByteArrayOSRequestEntity.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ByteArrayOSRequestEntity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.apache.http.Header;

--- a/src/main/java/microsoft/exchange/webservices/data/ByteArrayPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ByteArrayPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/CalendarActionResults.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CalendarActionResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CalendarEvent.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CalendarEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/CalendarEventDetails.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CalendarEventDetails.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CalendarFolder.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CalendarFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CalendarResponseMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CalendarResponseMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CalendarResponseMessageBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CalendarResponseMessageBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CalendarResponseObjectSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CalendarResponseObjectSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CalendarView.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CalendarView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/CallableMethod.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CallableMethod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.io.IOException;

--- a/src/main/java/microsoft/exchange/webservices/data/Callback.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Callback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.concurrent.Future;

--- a/src/main/java/microsoft/exchange/webservices/data/CancelMeetingMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CancelMeetingMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CancelMeetingMessageSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CancelMeetingMessageSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/Change.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Change.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ChangeCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ChangeCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ChangeType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ChangeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ComparisonMode.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ComparisonMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CompleteName.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CompleteName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ComplexFunctionDelegate.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ComplexFunctionDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 interface ComplexFunctionDelegate<T1 extends EwsServiceXmlReader> {

--- a/src/main/java/microsoft/exchange/webservices/data/ComplexProperty.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ComplexProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ComplexPropertyCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ComplexPropertyCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ComplexPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ComplexPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/ComplexPropertyDefinitionBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ComplexPropertyDefinitionBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/ConfigurationSettingsBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConfigurationSettingsBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.net.URI;

--- a/src/main/java/microsoft/exchange/webservices/data/Conflict.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Conflict.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ConflictResolutionMode.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConflictResolutionMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ConflictType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConflictType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ConnectingIdType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConnectingIdType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ConnectionFailureCause.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConnectionFailureCause.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Contact.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Contact.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.io.File;

--- a/src/main/java/microsoft/exchange/webservices/data/ContactGroup.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ContactGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ContactGroupSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ContactGroupSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/ContactSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ContactSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/ContactSource.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ContactSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ContactsFolder.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ContactsFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ContainedPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ContainedPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/ContainmentMode.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ContainmentMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Conversation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Conversation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ConversationAction.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConversationAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/ConversationActionType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConversationActionType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ConversationFlagStatus.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConversationFlagStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ConversationId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConversationId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ConversationIndexedItemView.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConversationIndexedItemView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/ConversationSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConversationSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/ConvertIdRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConvertIdRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/ConvertIdResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ConvertIdResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CopyFolderRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CopyFolderRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CopyItemRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CopyItemRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CreateAttachmentException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateAttachmentException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CreateAttachmentRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateAttachmentRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/CreateAttachmentResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateAttachmentResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CreateFolderRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateFolderRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Collection;

--- a/src/main/java/microsoft/exchange/webservices/data/CreateFolderResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateFolderResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.List;

--- a/src/main/java/microsoft/exchange/webservices/data/CreateItemRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateItemRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CreateItemRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateItemRequestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Collection;

--- a/src/main/java/microsoft/exchange/webservices/data/CreateItemResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateItemResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CreateItemResponseBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateItemResponseBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.List;

--- a/src/main/java/microsoft/exchange/webservices/data/CreateRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Collection;

--- a/src/main/java/microsoft/exchange/webservices/data/CreateResponseObjectRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateResponseObjectRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CreateResponseObjectResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateResponseObjectResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CreateRuleOperation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateRuleOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CreateUserConfigurationRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CreateUserConfigurationRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/CredentialConstants.java
+++ b/src/main/java/microsoft/exchange/webservices/data/CredentialConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 //These constants needs to be defined as per user configurations.

--- a/src/main/java/microsoft/exchange/webservices/data/DateTimePrecision.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DateTimePrecision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DateTimePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DateTimePropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import microsoft.exchange.webservices.data.util.DateTimeParser;

--- a/src/main/java/microsoft/exchange/webservices/data/DayOfTheWeek.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DayOfTheWeek.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Calendar;

--- a/src/main/java/microsoft/exchange/webservices/data/DayOfTheWeekCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DayOfTheWeekCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/DayOfTheWeekIndex.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DayOfTheWeekIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DeclineMeetingInvitationMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DeclineMeetingInvitationMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DefaultExtendedPropertySet.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DefaultExtendedPropertySet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DelegateFolderPermissionLevel.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DelegateFolderPermissionLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DelegateInformation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DelegateInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/DelegateManagementRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DelegateManagementRequestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DelegateManagementResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DelegateManagementResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/DelegatePermissions.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DelegatePermissions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/DelegateUser.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DelegateUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DelegateUserResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DelegateUserResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DeleteAttachmentException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DeleteAttachmentException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DeleteAttachmentRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DeleteAttachmentRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DeleteAttachmentResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DeleteAttachmentResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DeleteFolderRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DeleteFolderRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DeleteItemRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DeleteItemRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DeleteMode.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DeleteMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DeleteRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DeleteRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DeleteRuleOperation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DeleteRuleOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/DeleteUserConfigurationRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DeleteUserConfigurationRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DeletedOccurrenceInfo.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DeletedOccurrenceInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/DeletedOccurrenceInfoCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DeletedOccurrenceInfoCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DictionaryEntryProperty.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DictionaryEntryProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/DictionaryProperty.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DictionaryProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/DisconnectPhoneCallRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DisconnectPhoneCallRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DnsClient.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DnsClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.naming.NamingEnumeration;

--- a/src/main/java/microsoft/exchange/webservices/data/DnsException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DnsException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DnsRecord.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DnsRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DnsRecordType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DnsRecordType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DnsSrvRecord.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DnsSrvRecord.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.NoSuchElementException;

--- a/src/main/java/microsoft/exchange/webservices/data/DomainSettingError.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DomainSettingError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DomainSettingName.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DomainSettingName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/DoublePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DoublePropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/EWSConstants.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EWSConstants.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/EWSHttpException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EWSHttpException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/EditorBrowsable.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EditorBrowsable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/microsoft/exchange/webservices/data/EditorBrowsableState.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EditorBrowsableState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/EffectiveRights.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EffectiveRights.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/EffectiveRightsPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EffectiveRightsPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/EmailAddress.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EmailAddress.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/EmailAddressCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EmailAddressCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Iterator;

--- a/src/main/java/microsoft/exchange/webservices/data/EmailAddressDictionary.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EmailAddressDictionary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/EmailAddressEntry.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EmailAddressEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/EmailAddressKey.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EmailAddressKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/EmailMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EmailMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/EmailMessageSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EmailMessageSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/EmptyFolderRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EmptyFolderRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/EndDateRecurrenceRange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EndDateRecurrenceRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/EventType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EventType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/EwsEnum.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsEnum.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/microsoft/exchange/webservices/data/EwsSSLProtocolSocketFactory.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsSSLProtocolSocketFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;

--- a/src/main/java/microsoft/exchange/webservices/data/EwsServiceMultiResponseXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsServiceMultiResponseXmlReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLEventReader;

--- a/src/main/java/microsoft/exchange/webservices/data/EwsServiceXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsServiceXmlReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import microsoft.exchange.webservices.data.util.DateTimeParser;

--- a/src/main/java/microsoft/exchange/webservices/data/EwsServiceXmlWriter.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsServiceXmlWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.w3c.dom.*;

--- a/src/main/java/microsoft/exchange/webservices/data/EwsTraceListener.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsTraceListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.apache.commons.logging.Log;

--- a/src/main/java/microsoft/exchange/webservices/data/EwsUtilities.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsUtilities.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.io.ByteArrayInputStream;

--- a/src/main/java/microsoft/exchange/webservices/data/EwsX509TrustManager.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsX509TrustManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/EwsXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsXmlReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.namespace.QName;

--- a/src/main/java/microsoft/exchange/webservices/data/ExchangeCredentials.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExchangeCredentials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/ExchangeServerInfo.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExchangeServerInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExchangeService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.w3c.dom.Document;

--- a/src/main/java/microsoft/exchange/webservices/data/ExchangeServiceBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExchangeServiceBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.apache.http.client.protocol.HttpClientContext;

--- a/src/main/java/microsoft/exchange/webservices/data/ExchangeVersion.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExchangeVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ExecuteDiagnosticMethodRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExecuteDiagnosticMethodRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.w3c.dom.Node;

--- a/src/main/java/microsoft/exchange/webservices/data/ExecuteDiagnosticMethodResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExecuteDiagnosticMethodResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.w3c.dom.Document;

--- a/src/main/java/microsoft/exchange/webservices/data/ExpandGroupRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExpandGroupRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ExpandGroupResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExpandGroupResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ExpandGroupResults.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExpandGroupResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ExtendedProperty.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExtendedProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/ExtendedPropertyCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExtendedPropertyCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/ExtendedPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExtendedPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.UUID;

--- a/src/main/java/microsoft/exchange/webservices/data/FileAsMapping.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FileAsMapping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FileAttachment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FileAttachment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.io.*;

--- a/src/main/java/microsoft/exchange/webservices/data/FindConversationRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FindConversationRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FindConversationResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FindConversationResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/FindFolderRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FindFolderRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FindFolderResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FindFolderResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FindFoldersResults.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FindFoldersResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/FindItemRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FindItemRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FindItemResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FindItemResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/FindItemsResults.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FindItemsResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/FindRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FindRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FlaggedForAction.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FlaggedForAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Flags.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Flags.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/microsoft/exchange/webservices/data/Folder.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Folder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/FolderChange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FolderEvent.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/FolderId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FolderIdCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderIdCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FolderIdWrapper.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderIdWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FolderIdWrapperList.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderIdWrapperList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/FolderPermission.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderPermission.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/FolderPermissionCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderPermissionCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/FolderPermissionLevel.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderPermissionLevel.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 //TODO : Do we want to include more information about 

--- a/src/main/java/microsoft/exchange/webservices/data/FolderPermissionReadAccess.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderPermissionReadAccess.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FolderSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/FolderTraversal.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderTraversal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FolderView.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FolderWrapper.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FolderWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FormatException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FormatException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/FreeBusyViewType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FreeBusyViewType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GenericItemAttachment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GenericItemAttachment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GenericPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GenericPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.text.ParseException;

--- a/src/main/java/microsoft/exchange/webservices/data/GetAttachmentRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetAttachmentRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/GetAttachmentResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetAttachmentResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetDelegateRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetDelegateRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/GetDelegateResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetDelegateResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetDomainSettingsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetDomainSettingsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/GetDomainSettingsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetDomainSettingsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/GetDomainSettingsResponseCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetDomainSettingsResponseCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetEventsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetEventsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/GetEventsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetEventsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetEventsResults.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetEventsResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.*;

--- a/src/main/java/microsoft/exchange/webservices/data/GetFolderRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetFolderRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetFolderRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetFolderRequestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetFolderRequestForLoad.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetFolderRequestForLoad.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetFolderResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetFolderResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.List;

--- a/src/main/java/microsoft/exchange/webservices/data/GetInboxRulesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetInboxRulesRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/GetInboxRulesResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetInboxRulesResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetItemRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetItemRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetItemRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetItemRequestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetItemRequestForLoad.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetItemRequestForLoad.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetItemResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetItemResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.List;

--- a/src/main/java/microsoft/exchange/webservices/data/GetPasswordExpirationDateRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetPasswordExpirationDateRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/GetPasswordExpirationDateResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetPasswordExpirationDateResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/GetPhoneCallRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetPhoneCallRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetPhoneCallResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetPhoneCallResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetRoomListsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetRoomListsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetRoomListsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetRoomListsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetRoomsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetRoomsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetRoomsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetRoomsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/GetServerTimeZonesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetServerTimeZonesRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/GetServerTimeZonesResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetServerTimeZonesResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/GetStreamingEventsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetStreamingEventsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/GetStreamingEventsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetStreamingEventsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/GetStreamingEventsResults.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetStreamingEventsResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/GetUserAvailabilityRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetUserAvailabilityRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetUserAvailabilityResults.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetUserAvailabilityResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Collection;

--- a/src/main/java/microsoft/exchange/webservices/data/GetUserConfigurationRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetUserConfigurationRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/GetUserConfigurationResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetUserConfigurationResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/GetUserOofSettingsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetUserOofSettingsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/GetUserOofSettingsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetUserOofSettingsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GetUserSettingsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetUserSettingsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/GetUserSettingsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetUserSettingsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/GetUserSettingsResponseCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GetUserSettingsResponseCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GroupMember.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GroupMember.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GroupMemberCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GroupMemberCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/GroupMemberPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GroupMemberPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/GroupedFindItemsResults.java
+++ b/src/main/java/microsoft/exchange/webservices/data/GroupedFindItemsResults.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/Grouping.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Grouping.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/HangingServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/HangingServiceRequestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/HangingTraceStream.java
+++ b/src/main/java/microsoft/exchange/webservices/data/HangingTraceStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/HttpClientWebRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/HttpClientWebRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.apache.http.Header;

--- a/src/main/java/microsoft/exchange/webservices/data/HttpErrorException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/HttpErrorException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 

--- a/src/main/java/microsoft/exchange/webservices/data/HttpWebRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/HttpWebRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.apache.http.HttpException;

--- a/src/main/java/microsoft/exchange/webservices/data/IAction.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IAction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IAsyncResult.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IAsyncResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.concurrent.Future;

--- a/src/main/java/microsoft/exchange/webservices/data/IAutodiscoverRedirectionUrl.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IAutodiscoverRedirectionUrl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ICalendarActionProvider.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ICalendarActionProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IComplexPropertyChanged.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IComplexPropertyChanged.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IComplexPropertyChangedDelegate.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IComplexPropertyChangedDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ICreateComplexPropertyDelegate.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ICreateComplexPropertyDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ICreateServiceObjectWithAttachmentParam.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ICreateServiceObjectWithAttachmentParam.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ICreateServiceObjectWithServiceParam.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ICreateServiceObjectWithServiceParam.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ICustomXmlSerialization.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ICustomXmlSerialization.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamWriter;

--- a/src/main/java/microsoft/exchange/webservices/data/ICustomXmlUpdateSerializer.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ICustomXmlUpdateSerializer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/IDateTimePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IDateTimePropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IDisposable.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IDisposable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IFileAttachmentContentHandler.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IFileAttachmentContentHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.io.OutputStream;

--- a/src/main/java/microsoft/exchange/webservices/data/IFunc.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IFunc.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IFuncDelegate.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IFuncDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IFunction.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IFunction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IFunctionDelegate.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IFunctionDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/IGetObjectInstanceDelegate.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IGetObjectInstanceDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IGetPropertyDefinitionCallback.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IGetPropertyDefinitionCallback.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ILazyMember.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ILazyMember.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IOwnedProperty.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IOwnedProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IPredicate.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IPredicate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IPropertyBagChangedDelegate.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IPropertyBagChangedDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ISearchStringProvider.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ISearchStringProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ISelfValidate.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ISelfValidate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IServiceObjectChangedDelegate.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IServiceObjectChangedDelegate.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ITraceListener.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ITraceListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IdFormat.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IdFormat.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ImAddressDictionary.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ImAddressDictionary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ImAddressEntry.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ImAddressEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/ImAddressKey.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ImAddressKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ImpersonatedUserId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ImpersonatedUserId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Importance.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Importance.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IndexedPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IndexedPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/IntPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IntPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/InternetMessageHeader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/InternetMessageHeader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/InternetMessageHeaderCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/InternetMessageHeaderCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/InvalidOperationException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/InvalidOperationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Item.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Item.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ItemAttachment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemAttachment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ItemChange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ItemCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ItemEvent.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/ItemGroup.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ItemId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ItemIdCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemIdCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ItemIdWrapper.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemIdWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ItemIdWrapperList.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemIdWrapperList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ItemSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/ItemTraversal.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemTraversal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ItemView.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/ItemWrapper.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ItemWrapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/LazyMember.java
+++ b/src/main/java/microsoft/exchange/webservices/data/LazyMember.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/LegacyAvailabilityTimeZone.java
+++ b/src/main/java/microsoft/exchange/webservices/data/LegacyAvailabilityTimeZone.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.UUID;

--- a/src/main/java/microsoft/exchange/webservices/data/LegacyAvailabilityTimeZoneTime.java
+++ b/src/main/java/microsoft/exchange/webservices/data/LegacyAvailabilityTimeZoneTime.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/LegacyFreeBusyStatus.java
+++ b/src/main/java/microsoft/exchange/webservices/data/LegacyFreeBusyStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/LogicalOperator.java
+++ b/src/main/java/microsoft/exchange/webservices/data/LogicalOperator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Mailbox.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Mailbox.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/MailboxType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MailboxType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ManagedFolderInformation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ManagedFolderInformation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MapiPropertyType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MapiPropertyType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MapiTypeConverter.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MapiTypeConverter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.text.DateFormat;

--- a/src/main/java/microsoft/exchange/webservices/data/MapiTypeConverterMap.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MapiTypeConverterMap.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.HashMap;

--- a/src/main/java/microsoft/exchange/webservices/data/MapiTypeConverterMapEntry.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MapiTypeConverterMapEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.text.DateFormat;

--- a/src/main/java/microsoft/exchange/webservices/data/MeetingAttendeeType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingAttendeeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MeetingCancellation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingCancellation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MeetingMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/MeetingMessageSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingMessageSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/MeetingRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/MeetingRequestSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingRequestSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/MeetingRequestType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingRequestType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MeetingRequestsDeliveryScope.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingRequestsDeliveryScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MeetingResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MeetingResponseType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingResponseType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MeetingTimeZone.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingTimeZone.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MeetingTimeZonePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MeetingTimeZonePropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/MemberStatus.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MemberStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MessageBody.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MessageBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.apache.commons.logging.Log;

--- a/src/main/java/microsoft/exchange/webservices/data/MessageDisposition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MessageDisposition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MimeContent.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MimeContent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/MobilePhone.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MobilePhone.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Month.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Month.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MoveCopyFolderRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MoveCopyFolderRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MoveCopyFolderResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MoveCopyFolderResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.List;

--- a/src/main/java/microsoft/exchange/webservices/data/MoveCopyItemRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MoveCopyItemRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MoveCopyItemResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MoveCopyItemResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.List;

--- a/src/main/java/microsoft/exchange/webservices/data/MoveCopyRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MoveCopyRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MoveFolderRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MoveFolderRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MoveItemRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MoveItemRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/MultiResponseServiceRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MultiResponseServiceRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/NameResolution.java
+++ b/src/main/java/microsoft/exchange/webservices/data/NameResolution.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/NameResolutionCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/NameResolutionCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/NoEndRecurrenceRange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/NoEndRecurrenceRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/NotSupportedException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/NotSupportedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 public class NotSupportedException extends Exception {

--- a/src/main/java/microsoft/exchange/webservices/data/NotificationEvent.java
+++ b/src/main/java/microsoft/exchange/webservices/data/NotificationEvent.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/NotificationEventArgs.java
+++ b/src/main/java/microsoft/exchange/webservices/data/NotificationEventArgs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/NumberedRecurrenceRange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/NumberedRecurrenceRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/OccurrenceInfo.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OccurrenceInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/OccurrenceInfoCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OccurrenceInfoCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/OffsetBasePoint.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OffsetBasePoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/OofExternalAudience.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OofExternalAudience.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/OofReply.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OofReply.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/OofSettings.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OofSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/OofState.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OofState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/OrderByCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OrderByCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/OutParam.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OutParam.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/OutlookAccount.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OutlookAccount.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.HashMap;

--- a/src/main/java/microsoft/exchange/webservices/data/OutlookConfigurationSettings.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OutlookConfigurationSettings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/OutlookProtocol.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OutlookProtocol.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/OutlookProtocolType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OutlookProtocolType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/OutlookUser.java
+++ b/src/main/java/microsoft/exchange/webservices/data/OutlookUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.HashMap;

--- a/src/main/java/microsoft/exchange/webservices/data/PagedView.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PagedView.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/Param.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Param.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PermissionCollectionPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PermissionCollectionPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/PermissionScope.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PermissionScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PhoneCall.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PhoneCall.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PhoneCallId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PhoneCallId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PhoneCallState.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PhoneCallState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PhoneNumberDictionary.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PhoneNumberDictionary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PhoneNumberEntry.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PhoneNumberEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PhoneNumberKey.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PhoneNumberKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PhysicalAddressDictionary.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PhysicalAddressDictionary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PhysicalAddressEntry.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PhysicalAddressEntry.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/PhysicalAddressIndex.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PhysicalAddressIndex.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PhysicalAddressKey.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PhysicalAddressKey.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PlayOnPhoneRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PlayOnPhoneRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PlayOnPhoneResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PlayOnPhoneResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PostItem.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PostItem.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/PostItemSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PostItemSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/PostReply.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PostReply.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.List;

--- a/src/main/java/microsoft/exchange/webservices/data/PostReplySchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PostReplySchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PropertyBag.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PropertyBag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.*;

--- a/src/main/java/microsoft/exchange/webservices/data/PropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/PropertyDefinitionBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PropertyDefinitionBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/PropertyDefinitionFlags.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PropertyDefinitionFlags.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PropertyException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PropertyException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PropertySet.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PropertySet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/ProtocolConnection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ProtocolConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ProtocolConnectionCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ProtocolConnectionCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/PullSubscription.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PullSubscription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/PushSubscription.java
+++ b/src/main/java/microsoft/exchange/webservices/data/PushSubscription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Recurrence.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Recurrence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/RecurrencePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RecurrencePropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/RecurrenceRange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RecurrenceRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/RecurringAppointmentMasterId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RecurringAppointmentMasterId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/RefParam.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RefParam.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/RelativeDayOfMonthTransition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RelativeDayOfMonthTransition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/RemoveDelegateRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RemoveDelegateRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/RemoveFromCalendar.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RemoveFromCalendar.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.List;

--- a/src/main/java/microsoft/exchange/webservices/data/RequiredServerVersion.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RequiredServerVersion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/microsoft/exchange/webservices/data/ResolveNameSearchLocation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ResolveNameSearchLocation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ResolveNamesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ResolveNamesRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.HashMap;

--- a/src/main/java/microsoft/exchange/webservices/data/ResolveNamesResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ResolveNamesResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ResponseActions.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ResponseActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ResponseMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ResponseMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ResponseMessageSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ResponseMessageSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ResponseMessageType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ResponseMessageType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ResponseObject.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ResponseObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ResponseObjectSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ResponseObjectSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/ResponseObjectsPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ResponseObjectsPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/Rule.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Rule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/RuleActions.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RuleActions.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/RuleCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RuleCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/RuleError.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RuleError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/RuleErrorCode.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RuleErrorCode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/RuleErrorCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RuleErrorCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/RuleOperation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RuleOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/RuleOperationError.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RuleOperationError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Iterator;

--- a/src/main/java/microsoft/exchange/webservices/data/RuleOperationErrorCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RuleOperationErrorCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/RulePredicateDateRange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RulePredicateDateRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/RulePredicateSizeRange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RulePredicateSizeRange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/RulePredicates.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RulePredicates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/RuleProperty.java
+++ b/src/main/java/microsoft/exchange/webservices/data/RuleProperty.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 public enum RuleProperty {

--- a/src/main/java/microsoft/exchange/webservices/data/SafeXmlDocument.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SafeXmlDocument.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.w3c.dom.DOMImplementation;

--- a/src/main/java/microsoft/exchange/webservices/data/SafeXmlFactory.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SafeXmlFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLInputFactory;

--- a/src/main/java/microsoft/exchange/webservices/data/SafeXmlSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SafeXmlSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.bind.ValidationEventHandler;

--- a/src/main/java/microsoft/exchange/webservices/data/Schema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Schema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/microsoft/exchange/webservices/data/SearchFilter.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SearchFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/SearchFolder.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SearchFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SearchFolderParameters.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SearchFolderParameters.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SearchFolderSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SearchFolderSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/SearchFolderTraversal.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SearchFolderTraversal.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SendCancellationsMode.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SendCancellationsMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SendInvitationsMode.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SendInvitationsMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SendInvitationsOrCancellationsMode.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SendInvitationsOrCancellationsMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SendItemRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SendItemRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Sensitivity.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Sensitivity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceError.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceErrorHandling.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceErrorHandling.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceLocalException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceLocalException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceObject.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceObject.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceObjectDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceObjectDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceObjectInfo.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceObjectInfo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceObjectPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceObjectPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceObjectPropertyException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceObjectPropertyException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceObjectSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceObjectSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.lang.reflect.Field;

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceObjectType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceObjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceRemoteException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceRemoteException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceRequestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceRequestException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceRequestException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceResponseCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceResponseCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Enumeration;

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceResponseException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceResponseException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceResult.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceValidationException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceValidationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceVersionException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceVersionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceXmlDeserializationException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceXmlDeserializationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ServiceXmlSerializationException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ServiceXmlSerializationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SetRuleOperation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SetRuleOperation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SetUserOofSettingsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SetUserOofSettingsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SimplePropertyBag.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SimplePropertyBag.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.*;

--- a/src/main/java/microsoft/exchange/webservices/data/SimpleServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SimpleServiceRequestBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.apache.commons.logging.Log;

--- a/src/main/java/microsoft/exchange/webservices/data/SoapFaultDetails.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SoapFaultDetails.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/SortDirection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SortDirection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/StandardUser.java
+++ b/src/main/java/microsoft/exchange/webservices/data/StandardUser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/StartTimeZonePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/StartTimeZonePropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/StreamingSubscription.java
+++ b/src/main/java/microsoft/exchange/webservices/data/StreamingSubscription.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/StreamingSubscriptionConnection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/StreamingSubscriptionConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.io.Closeable;

--- a/src/main/java/microsoft/exchange/webservices/data/StringList.java
+++ b/src/main/java/microsoft/exchange/webservices/data/StringList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/StringPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/StringPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/Strings.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Strings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 public abstract class Strings {

--- a/src/main/java/microsoft/exchange/webservices/data/SubscribeRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SubscribeRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/SubscribeResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SubscribeResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/SubscribeToPullNotificationsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SubscribeToPullNotificationsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/SubscribeToPushNotificationsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SubscribeToPushNotificationsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/SubscribeToStreamingNotificationsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SubscribeToStreamingNotificationsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SubscriptionBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SubscriptionBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SubscriptionErrorEventArgs.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SubscriptionErrorEventArgs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Suggestion.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Suggestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/SuggestionQuality.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SuggestionQuality.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SuggestionsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SuggestionsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/SuppressReadReceipt.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SuppressReadReceipt.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SyncFolderHierarchyRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SyncFolderHierarchyRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SyncFolderHierarchyResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SyncFolderHierarchyResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SyncFolderItemsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SyncFolderItemsRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SyncFolderItemsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SyncFolderItemsResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SyncFolderItemsScope.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SyncFolderItemsScope.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/SyncResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/SyncResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Task.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Task.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Date;

--- a/src/main/java/microsoft/exchange/webservices/data/TaskDelegationState.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TaskDelegationState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/TaskDelegationStatePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TaskDelegationStatePropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/TaskMode.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TaskMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/TaskSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TaskSchema.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/TaskStatus.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TaskStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/TasksFolder.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TasksFolder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/Time.java
+++ b/src/main/java/microsoft/exchange/webservices/data/Time.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.Calendar;

--- a/src/main/java/microsoft/exchange/webservices/data/TimeChange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TimeChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.text.SimpleDateFormat;

--- a/src/main/java/microsoft/exchange/webservices/data/TimeChangeRecurrence.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TimeChangeRecurrence.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/TimeSpan.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TimeSpan.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/TimeSpanPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TimeSpanPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.EnumSet;

--- a/src/main/java/microsoft/exchange/webservices/data/TimeSuggestion.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TimeSuggestion.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/TimeWindow.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TimeWindow.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/TimeZoneConversionException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TimeZoneConversionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/TimeZoneDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TimeZoneDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.*;

--- a/src/main/java/microsoft/exchange/webservices/data/TimeZonePeriod.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TimeZonePeriod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/TimeZonePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TimeZonePropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/TimeZoneTransition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TimeZoneTransition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/TimeZoneTransitionGroup.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TimeZoneTransitionGroup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/TokenCredentials.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TokenCredentials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.net.URISyntaxException;

--- a/src/main/java/microsoft/exchange/webservices/data/TraceFlags.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TraceFlags.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/TypedPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/TypedPropertyDefinition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/UnifiedMessaging.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UnifiedMessaging.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/UniqueBody.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UniqueBody.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/UnsubscribeRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UnsubscribeRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/UpdateDelegateRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UpdateDelegateRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/UpdateFolderRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UpdateFolderRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/UpdateFolderResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UpdateFolderResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/UpdateInboxRulesException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UpdateInboxRulesException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/UpdateInboxRulesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UpdateInboxRulesRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/UpdateInboxRulesResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UpdateInboxRulesResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/UpdateItemRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UpdateItemRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/UpdateItemResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UpdateItemResponse.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/UpdateUserConfigurationRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UpdateUserConfigurationRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/UserConfiguration.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UserConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/UserConfigurationDictionary.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UserConfigurationDictionary.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import microsoft.exchange.webservices.data.util.DateTimeParser;

--- a/src/main/java/microsoft/exchange/webservices/data/UserConfigurationDictionaryObjectType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UserConfigurationDictionaryObjectType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/UserConfigurationProperties.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UserConfigurationProperties.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/UserId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UserId.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/UserSettingError.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UserSettingError.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/UserSettingName.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UserSettingName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/ViewBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ViewBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/WSSecurityBasedCredentials.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WSSecurityBasedCredentials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamException;

--- a/src/main/java/microsoft/exchange/webservices/data/WaitHandle.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WaitHandle.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 public class WaitHandle {

--- a/src/main/java/microsoft/exchange/webservices/data/WebAsyncCallStateAnchor.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WebAsyncCallStateAnchor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 public class WebAsyncCallStateAnchor {

--- a/src/main/java/microsoft/exchange/webservices/data/WebClientUrl.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WebClientUrl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/WebClientUrlCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WebClientUrlCollection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/WebCredentials.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WebCredentials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/WebExceptionStatus.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WebExceptionStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 public enum WebExceptionStatus {

--- a/src/main/java/microsoft/exchange/webservices/data/WebProxy.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WebProxy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/WebProxyCredentials.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WebProxyCredentials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 public class WebProxyCredentials {

--- a/src/main/java/microsoft/exchange/webservices/data/WellKnownFolderName.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WellKnownFolderName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/WindowsLiveCredentials.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WindowsLiveCredentials.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 public class WindowsLiveCredentials extends WSSecurityBasedCredentials {

--- a/src/main/java/microsoft/exchange/webservices/data/WorkingHours.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WorkingHours.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/WorkingPeriod.java
+++ b/src/main/java/microsoft/exchange/webservices/data/WorkingPeriod.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/main/java/microsoft/exchange/webservices/data/XmlAttributeNames.java
+++ b/src/main/java/microsoft/exchange/webservices/data/XmlAttributeNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/XmlDtdException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/XmlDtdException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/XmlElementNames.java
+++ b/src/main/java/microsoft/exchange/webservices/data/XmlElementNames.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/XmlException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/XmlException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 public class XmlException extends Exception {

--- a/src/main/java/microsoft/exchange/webservices/data/XmlNameTable.java
+++ b/src/main/java/microsoft/exchange/webservices/data/XmlNameTable.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/XmlNamespace.java
+++ b/src/main/java/microsoft/exchange/webservices/data/XmlNamespace.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 /**

--- a/src/main/java/microsoft/exchange/webservices/data/XmlNodeType.java
+++ b/src/main/java/microsoft/exchange/webservices/data/XmlNodeType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import javax.xml.stream.XMLStreamConstants;

--- a/src/main/java/microsoft/exchange/webservices/data/util/DateTimeParser.java
+++ b/src/main/java/microsoft/exchange/webservices/data/util/DateTimeParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data.util;
 
 import java.util.Date;

--- a/src/test/java/microsoft/exchange/webservices/data/BaseTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/BaseTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.junit.BeforeClass;

--- a/src/test/java/microsoft/exchange/webservices/data/EmailAddressTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/EmailAddressTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.junit.Assert;

--- a/src/test/java/microsoft/exchange/webservices/data/EwsUtilitiesTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/EwsUtilitiesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.junit.Assert;

--- a/src/test/java/microsoft/exchange/webservices/data/ExtendedPropertyCollectionTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/ExtendedPropertyCollectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import java.util.ArrayList;

--- a/src/test/java/microsoft/exchange/webservices/data/GetUserSettingsRequestTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/GetUserSettingsRequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 

--- a/src/test/java/microsoft/exchange/webservices/data/PropertyBagTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/PropertyBagTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.junit.Test;

--- a/src/test/java/microsoft/exchange/webservices/data/TaskTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/TaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.hamcrest.core.IsEqual;

--- a/src/test/java/microsoft/exchange/webservices/data/TimeSpanTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/TimeSpanTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.junit.Test;

--- a/src/test/java/microsoft/exchange/webservices/data/UserConfigurationDictionaryTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/UserConfigurationDictionaryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data;
 
 import org.junit.Assert;

--- a/src/test/java/microsoft/exchange/webservices/data/util/DateTimeParserTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/util/DateTimeParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * The MIT License
  * Copyright (c) 2012 Microsoft Corporation
  *
@@ -20,6 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 package microsoft.exchange.webservices.data.util;
 
 import org.junit.Before;


### PR DESCRIPTION
- the license header was treated as a normal javadoc due to /** -> /*
solves the problem
- there should be a blank between license header and package