### PR TITLE
#223 Avoid NullPointerException while parsing response

### DIFF
--- a/ews-java-api.iml
+++ b/ews-java-api.iml
@@ -18,5 +18,6 @@
     <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.11" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-all:1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-all:1.9.5" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -147,6 +147,13 @@
             <version>1.3</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/microsoft/exchange/webservices/data/EwsXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsXmlReader.java
@@ -164,9 +164,8 @@ class EwsXmlReader {
 
   /**
    * Reads the specified node type.
-   * 
-   * @param keepWhiteSpace Do not remove whitespace characters if true
    *
+   * @param keepWhiteSpace Do not remove whitespace characters if true
    * @throws ServiceXmlDeserializationException  the service xml deserialization exception
    * @throws javax.xml.stream.XMLStreamException the xML stream exception
    */
@@ -187,7 +186,7 @@ class EwsXmlReader {
             if (characters.isIgnorableWhiteSpace()
                 || characters.isWhiteSpace()) {
               continue;
-          }
+            }
         }
         this.prevEvent = this.presentEvent;
         this.presentEvent = event;
@@ -417,6 +416,7 @@ class EwsXmlReader {
       ServiceXmlDeserializationException {
     return readValue(false);
   }
+
   /**
    * Reads the value. Should return content element or text node as string
    * Present event must be START ELEMENT. After executing this function
@@ -441,7 +441,7 @@ class EwsXmlReader {
             Characters characters = (Characters) this.presentEvent;
             if (keepWhiteSpace || (!characters.isIgnorableWhiteSpace()
                 && !characters.isWhiteSpace())) {
-              if (characters.getData().length() != 0) {
+              if (characters.getData() != null && characters.getData().length() != 0) {
                 elementValue.append(characters.getData());
               }
             }
@@ -462,17 +462,18 @@ class EwsXmlReader {
     } else if (this.presentEvent.getEventType() == XmlNodeType.CHARACTERS
         && this.presentEvent.isCharacters()) {
                         /*
-			 * if(this.presentEvent.asCharacters().getData().equals("<")) {
+                         * if(this.presentEvent.asCharacters().getData().equals("<")) {
 			 */
-      StringBuffer data = new StringBuffer(this.presentEvent
-          .asCharacters().getData());
+      final String charData = this.presentEvent
+          .asCharacters().getData();
+      StringBuffer data = new StringBuffer(charData == null ? "" : charData);
       do {
         this.read(keepWhiteSpace);
         if (this.getNodeType().nodeType == XmlNodeType.CHARACTERS) {
           Characters characters = (Characters) this.presentEvent;
           if (keepWhiteSpace || (!characters.isIgnorableWhiteSpace()
               && !characters.isWhiteSpace())) {
-            if (characters.getData().length() != 0) {
+            if (characters.getData() != null && characters.getData().length() != 0) {
               data.append(characters.getData());
             }
           }

--- a/src/test/java/microsoft/exchange/webservices/data/EwsXmlReaderTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/EwsXmlReaderTest.java
@@ -1,0 +1,100 @@
+/*
+ * The MIT License
+ * Copyright (c) 2012 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package microsoft.exchange.webservices.data;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.events.Characters;
+import javax.xml.stream.events.XMLEvent;
+import java.io.ByteArrayInputStream;
+
+import static org.mockito.Mockito.doReturn;
+
+public class EwsXmlReaderTest {
+
+  @Mock(name="presentEvent") XMLEvent presentEvent;
+  @Mock(name="xmlReader") XMLEventReader xmlReader;
+  @InjectMocks EwsXmlReader impl;
+  @Mock Characters character;
+
+  @Before
+  public void setUp() throws Exception {
+    impl = new EwsXmlReader(new ByteArrayInputStream(("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        + "<test></test>").getBytes("UTF-8")));
+    MockitoAnnotations.initMocks(this);
+
+  }
+
+  @Test
+  public void testReadValueWhenCharacterDataIsNull() throws Exception {
+
+    doReturn(false).when(presentEvent).isStartElement();
+    doReturn(XmlNodeType.CHARACTERS).when(presentEvent).getEventType();
+    doReturn(true).when(presentEvent).isCharacters();
+    doReturn(character).when(presentEvent).asCharacters();
+
+    //next event, then end event, then no more event
+    doReturn(true).doReturn(true).doReturn(false).when(xmlReader).hasNext();
+    Characters nextEvent = Mockito.mock(Characters.class);
+    doReturn(true).when(nextEvent).isCharacters();
+    doReturn(XmlNodeType.CHARACTERS).when(nextEvent).getEventType();
+    XMLEvent endEvent = Mockito.mock(XMLEvent.class);
+    doReturn(nextEvent).doReturn(endEvent).when(xmlReader).nextEvent();
+    doReturn(true).when(endEvent).isEndElement();
+
+    impl.readValue(true);  //must not throw npe even if character.getData() is null
+
+    Assert.assertNull(character.getData());
+  }
+
+  @Test
+  public void testReadValueWhenCharacterDataIsNullForStartElement() throws Exception {
+
+    doReturn(true).when(presentEvent).isStartElement();
+    doReturn(XmlNodeType.CHARACTERS).when(presentEvent).getEventType();
+    doReturn(true).when(presentEvent).isCharacters();
+    doReturn(character).when(presentEvent).asCharacters();
+
+    //next event, then end event, then no more event
+    doReturn(true).doReturn(true).doReturn(false).when(xmlReader).hasNext();
+    Characters nextEvent = Mockito.mock(Characters.class);
+    doReturn(true).when(nextEvent).isCharacters();
+    doReturn(XmlNodeType.CHARACTERS).when(nextEvent).getEventType();
+    XMLEvent endEvent = Mockito.mock(XMLEvent.class);
+    doReturn(nextEvent).doReturn(endEvent).when(xmlReader).nextEvent();
+    doReturn(true).when(endEvent).isEndElement();
+
+    impl.readValue(true);  //must not throw npe even if character.getData() is null
+
+    Assert.assertNull(character.getData());
+  }
+
+}


### PR DESCRIPTION
- check for null are added before using data field from javax.xml.stream.events.Character
see issue #223
