### PR TITLE
Fix keep-alive handling.

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/HangingServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/HangingServiceRequestBase.java
@@ -260,7 +260,7 @@ abstract class HangingServiceRequestBase extends ServiceRequestBase {
               EwsServiceMultiResponseXmlReader.create(tracingStream, getService());
           responseObject = this.readResponse(ewsXmlReader);
           this.responseHandler.handleResponseObject(responseObject);
-				/*	}catch(Exception ex){
+                                /*	}catch(Exception ex){
 						this.disconnect(HangingRequestDisconnectReason.Exception, ex);
 						return;
 						
@@ -343,8 +343,11 @@ abstract class HangingServiceRequestBase extends ServiceRequestBase {
    */
   protected void disconnect() {
     synchronized (this) {
-      //this.request.close();
-      this.response.close();
+      try {
+        this.response.close();
+      } catch (IOException e) {
+        // Ignore exception on disconnection
+      }
       this.disconnect(HangingRequestDisconnectReason.UserInitiated, null);
     }
   }
@@ -358,7 +361,11 @@ abstract class HangingServiceRequestBase extends ServiceRequestBase {
   protected void disconnect(HangingRequestDisconnectReason reason,
       Exception exception) {
     if (this.isConnected()) {
-      this.response.close();
+      try {
+        this.response.close();
+      } catch (IOException e) {
+        // Ignore exception on disconnection
+      }
       this.internalOnDisconnect(reason, exception);
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/HttpWebRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/HttpWebRequest.java
@@ -475,7 +475,7 @@ abstract class HttpWebRequest {
   /**
    * Close.
    */
-  public abstract void close();
+  public abstract void close() throws IOException;
 
   /**
    * Prepare connection.


### PR DESCRIPTION
We now try to keep the connection alive by simply consuming the full response. If that does not work, we revert to the old behaviour (to make sure we always close the underlying resources).

This is a bit of a hack, but the whole library is still build around the HttpClient 3 behaviour (where you had to close the request), whereas in HttpClient you have to consume the response (or close the request if there is no response, imho this is a flaw in the API of HttpClient 4).