### PR TITLE
Convert DateTimeParser to DateTimeUtils

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/DateTimePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/DateTimePropertyDefinition.java
@@ -23,7 +23,7 @@
 
 package microsoft.exchange.webservices.data;
 
-import microsoft.exchange.webservices.data.util.DateTimeParser;
+import microsoft.exchange.webservices.data.util.DateTimeUtils;
 
 import java.util.Date;
 import java.util.EnumSet;
@@ -89,8 +89,7 @@ class DateTimePropertyDefinition extends PropertyDefinition {
   protected void loadPropertyValueFromXml(EwsServiceXmlReader reader, PropertyBag propertyBag)
       throws Exception {
     String value = reader.readElementValue(XmlNamespace.Types, getXmlElement());
-    propertyBag.setObjectFromPropertyDefinition(this, new DateTimeParser()
-        .convertDateTimeStringToDate(value));
+    propertyBag.setObjectFromPropertyDefinition(this, DateTimeUtils.convertDateTimeStringToDate(value));
   }
 
 

--- a/src/main/java/microsoft/exchange/webservices/data/EwsServiceXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/EwsServiceXmlReader.java
@@ -23,11 +23,10 @@
 
 package microsoft.exchange.webservices.data;
 
-import microsoft.exchange.webservices.data.util.DateTimeParser;
+import microsoft.exchange.webservices.data.util.DateTimeUtils;
 
 import java.io.InputStream;
 import java.text.DateFormat;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
@@ -38,8 +37,6 @@ import java.util.TimeZone;
  * XML reader.
  */
 class EwsServiceXmlReader extends EwsXmlReader {
-
-  private DateTimeParser dateTimeParser = new DateTimeParser();
 
   /**
    * The service.
@@ -66,7 +63,7 @@ class EwsServiceXmlReader extends EwsXmlReader {
    * @throws Exception the exception
    */
   public Date readElementValueAsDateTime() throws Exception {
-    return dateTimeParser.convertDateTimeStringToDate(readElementValue());
+    return DateTimeUtils.convertDateTimeStringToDate(readElementValue());
   }
 
   /**
@@ -76,7 +73,7 @@ class EwsServiceXmlReader extends EwsXmlReader {
    * @throws Exception
    */
   public Date readElementValueAsUnspecifiedDate() throws Exception {
-    return dateTimeParser.convertDateStringToDate(readElementValue());
+    return DateTimeUtils.convertDateStringToDate(readElementValue());
   }
 
   /**
@@ -138,7 +135,7 @@ class EwsServiceXmlReader extends EwsXmlReader {
    * @throws Exception the exception
    */
   public Date readElementValueAsDateTime(XmlNamespace xmlNamespace, String localName) throws Exception {
-    return dateTimeParser.convertDateTimeStringToDate(readElementValue(xmlNamespace, localName));
+    return DateTimeUtils.convertDateTimeStringToDate(readElementValue(xmlNamespace, localName));
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/UserConfigurationDictionary.java
+++ b/src/main/java/microsoft/exchange/webservices/data/UserConfigurationDictionary.java
@@ -23,7 +23,7 @@
 
 package microsoft.exchange.webservices.data;
 
-import microsoft.exchange.webservices.data.util.DateTimeParser;
+import microsoft.exchange.webservices.data.util.DateTimeUtils;
 
 import javax.xml.stream.XMLStreamException;
 import java.lang.reflect.Array;
@@ -596,7 +596,7 @@ public final class UserConfigurationDictionary extends ComplexProperty
     } else if (type.equals(UserConfigurationDictionaryObjectType.ByteArray)) {
       dictionaryObject = Base64EncoderStream.decode(value.get(0));
     } else if (type.equals(UserConfigurationDictionaryObjectType.DateTime)) {
-      Date dateTime = new DateTimeParser().convertDateTimeStringToDate(value.get(0));
+      Date dateTime = DateTimeUtils.convertDateTimeStringToDate(value.get(0));
       if (dateTime != null) {
         dictionaryObject = dateTime;
       } else {

--- a/src/main/java/microsoft/exchange/webservices/data/util/DateTimeUtils.java
+++ b/src/main/java/microsoft/exchange/webservices/data/util/DateTimeUtils.java
@@ -28,23 +28,15 @@ import java.util.Date;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-public class DateTimeParser {
+public final class DateTimeUtils {
 
-  private final DateTimeFormatter[] dateTimeFormats = {
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ").withZoneUTC(),
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").withZoneUTC(),
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ").withZoneUTC(),
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss").withZoneUTC(),
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS").withZoneUTC(),
-      DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSS").withZoneUTC(),
-      DateTimeFormat.forPattern("yyyy-MM-ddZ").withZoneUTC(),
-      DateTimeFormat.forPattern("yyyy-MM-dd").withZoneUTC()
-  };
+  private static final DateTimeFormatter[] DATE_TIME_FORMATS = createDateTimeFormats();
+  private static final DateTimeFormatter[] DATE_FORMATS = createDateFormats();
 
-  private final DateTimeFormatter[] dateFormats = {
-      DateTimeFormat.forPattern("yyyy-MM-ddZ").withZoneUTC(),
-      DateTimeFormat.forPattern("yyyy-MM-dd").withZoneUTC()
-  };
+
+  private DateTimeUtils() {
+    throw new UnsupportedOperationException();
+  }
 
 
   /**
@@ -58,7 +50,7 @@ public class DateTimeParser {
    *
    * @throws java.lang.IllegalArgumentException If string can not be parsed.
    */
-  public Date convertDateTimeStringToDate(String value) {
+  public static Date convertDateTimeStringToDate(String value) {
     return parseInternal(value, false);
   }
 
@@ -72,11 +64,12 @@ public class DateTimeParser {
    *
    * @throws java.lang.IllegalArgumentException If string can not be parsed.
    */
-  public Date convertDateStringToDate(String value) {
+  public static Date convertDateStringToDate(String value) {
     return parseInternal(value, true);
   }
 
-  private Date parseInternal(String value, boolean dateOnly) {
+
+  private static Date parseInternal(String value, boolean dateOnly) {
     String originalValue = value;
 
     if (value == null || value.isEmpty()) {
@@ -87,7 +80,7 @@ public class DateTimeParser {
         value = value.substring(0, value.length() - 1) + "Z";
       }
 
-      DateTimeFormatter[] formats = dateOnly ? dateFormats : dateTimeFormats;
+      DateTimeFormatter[] formats = dateOnly ? DATE_FORMATS : DATE_TIME_FORMATS;
       for (DateTimeFormatter format : formats) {
         try {
           return format.parseDateTime(value).toDate();
@@ -100,4 +93,25 @@ public class DateTimeParser {
     throw new IllegalArgumentException(
         String.format("Date String %s not in valid UTC/local format", originalValue));
   }
+
+  private static DateTimeFormatter[] createDateTimeFormats() {
+    return new DateTimeFormatter[] {
+        DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ssZ").withZoneUTC(),
+        DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ").withZoneUTC(),
+        DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSZ").withZoneUTC(),
+        DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss").withZoneUTC(),
+        DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSS").withZoneUTC(),
+        DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSSS").withZoneUTC(),
+        DateTimeFormat.forPattern("yyyy-MM-ddZ").withZoneUTC(),
+        DateTimeFormat.forPattern("yyyy-MM-dd").withZoneUTC()
+    };
+  }
+
+  private static DateTimeFormatter[] createDateFormats() {
+    return new DateTimeFormatter[] {
+        DateTimeFormat.forPattern("yyyy-MM-ddZ").withZoneUTC(),
+        DateTimeFormat.forPattern("yyyy-MM-dd").withZoneUTC()
+    };
+  }
+
 }

--- a/src/test/java/microsoft/exchange/webservices/data/util/DateTimeUtilsTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/util/DateTimeUtilsTest.java
@@ -23,7 +23,6 @@
 
 package microsoft.exchange.webservices.data.util;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -37,29 +36,20 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 @RunWith(JUnit4.class)
-public class DateTimeParserTest {
+public class DateTimeUtilsTest {
 
-  private DateTimeParser parser;
-
-  @Before
-  public void setUp() {
-    parser = new DateTimeParser();
-  }
-
-
-
-  // Tests for DateTimeParser.convertDateTimeStringToDate()
+  // Tests for DateTimeUtils.convertDateTimeStringToDate()
 
   @Test
   public void testDateTimeEmpty() {
-    assertNull(parser.convertDateTimeStringToDate(null));
-    assertNull(parser.convertDateTimeStringToDate(""));
+    assertNull(DateTimeUtils.convertDateTimeStringToDate(null));
+    assertNull(DateTimeUtils.convertDateTimeStringToDate(""));
   }
 
   @Test
   public void testDateTimeZulu() {
     String dateString = "2015-01-08T10:11:12Z";
-    Date parsed = parser.convertDateTimeStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateTimeStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));
@@ -73,7 +63,7 @@ public class DateTimeParserTest {
   @Test
   public void testDateTimeZuluLowerZ() {
     String dateString = "2015-01-08T10:11:12z";
-    Date parsed = parser.convertDateTimeStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateTimeStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));
@@ -87,7 +77,7 @@ public class DateTimeParserTest {
   @Test
   public void testDateTimeZuluWithPrecision() {
     String dateString = "2015-01-08T10:11:12.123Z";
-    Date parsed = parser.convertDateTimeStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateTimeStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));
@@ -101,7 +91,7 @@ public class DateTimeParserTest {
   @Test
   public void testDateTimeZuluWithMilliseconds() {
     String dateString = "9999-12-30T23:59:59.9999999Z";
-    Date parsed = parser.convertDateTimeStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateTimeStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(9999, calendar.get(Calendar.YEAR));
@@ -115,7 +105,7 @@ public class DateTimeParserTest {
   @Test
    public void testDateTimeWithTimeZone() {
     String dateString = "2015-01-08T10:11:12+0200";
-    Date parsed = parser.convertDateTimeStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateTimeStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));
@@ -129,7 +119,7 @@ public class DateTimeParserTest {
   @Test
   public void testDateTimeWithTimeZoneWithColon() {
     String dateString = "2015-01-08T10:11:12-02:00";
-    Date parsed = parser.convertDateTimeStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateTimeStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));
@@ -143,7 +133,7 @@ public class DateTimeParserTest {
   @Test
   public void testDateTime() {
     String dateString = "2015-01-08T10:11:12";
-    Date parsed = parser.convertDateTimeStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateTimeStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));
@@ -157,7 +147,7 @@ public class DateTimeParserTest {
   @Test
   public void testDateZulu() {
     String dateString = "2015-01-08Z";
-    Date parsed = parser.convertDateTimeStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateTimeStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));
@@ -168,7 +158,7 @@ public class DateTimeParserTest {
   @Test
   public void testDateOnly() {
     String dateString = "2015-01-08";
-    Date parsed = parser.convertDateTimeStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateTimeStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));
@@ -178,18 +168,18 @@ public class DateTimeParserTest {
 
 
 
-  // Tests for DateTimeParser.convertDateStringToDate()
+  // Tests for DateTimeUtils.convertDateStringToDate()
 
   @Test
   public void testDateOnlyEmpty() {
-    assertNull(parser.convertDateStringToDate(null));
-    assertNull(parser.convertDateStringToDate(""));
+    assertNull(DateTimeUtils.convertDateStringToDate(null));
+    assertNull(DateTimeUtils.convertDateStringToDate(""));
   }
 
   @Test
    public void testDateOnlyZulu() {
     String dateString = "2015-01-08Z";
-    Date parsed = parser.convertDateStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));
@@ -203,7 +193,7 @@ public class DateTimeParserTest {
   @Test
   public void testDateOnlyZuluWithLowerZ() {
     String dateString = "2015-01-08z";
-    Date parsed = parser.convertDateStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));
@@ -217,7 +207,7 @@ public class DateTimeParserTest {
   @Test
   public void testDateOnlyWithTimeZone() {
     String dateString = "2015-01-08+0200";
-    Date parsed = parser.convertDateStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));
@@ -231,7 +221,7 @@ public class DateTimeParserTest {
   @Test
   public void testDateOnlyWithTimeZoneWithColon() {
     String dateString = "2015-01-08-02:00";
-    Date parsed = parser.convertDateStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));
@@ -245,7 +235,7 @@ public class DateTimeParserTest {
   @Test
   public void testDateOnlyWithoutTimeZone() {
     String dateString = "2015-01-08";
-    Date parsed = parser.convertDateStringToDate(dateString);
+    Date parsed = DateTimeUtils.convertDateStringToDate(dateString);
     Calendar calendar = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
     calendar.setTime(parsed);
     assertEquals(2015, calendar.get(Calendar.YEAR));


### PR DESCRIPTION
I continue my research with JProfiler (https://github.com/OfficeDev/ews-java-api/pull/232):

Class `DateTimeParser` creates DateTimeFormats & DateTimeFormatters (when it is instantiated). It is very expensive (see DateTimeFormat#forPattern & DateTimeFormatter#withZoneUTC). Class `DateTimeParser` is used in very critical places like `EwsServiceXmlReader`, so it is important to be as fast as possible.

Classes `DateTimeFormat` and `DateTimeFormatters` are thread-safe, so I converted DateTimeParser to utility class.