### PR TITLE
Autodeployment for snapshots

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,24 @@
+# The MIT License
+# Copyright (c) 2012 Microsoft Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 language: java
 
 jdk:
@@ -5,8 +26,22 @@ jdk:
   - oraclejdk7
   - openjdk6
 
+# enable container-based infrastructure
+sudo: false
+
+# cache local repository for speed of build
+cache:
+  directories:
+    - $HOME/.m2/repository
+
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/04643d955d03eb39e24e
+     - https://webhooks.gitter.im/e/04643d955d03eb39e24e
     on_success: change
+
+before_install:
+  - chmod +x ./deploy_snapshot.sh
+
+after_success:
+  - ./deploy_snapshot.sh

--- a/deploy_snapshot.sh
+++ b/deploy_snapshot.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# The MIT License
+# Copyright (c) 2012 Microsoft Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+if [ "$TRAVIS_REPO_SLUG" != "OfficeDev/ews-java-api" ]; then 
+	echo "[DEPLOY] Skipping snapshot deployment for repo:'$TRAVIS_REPO_SLUG'."
+elif [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+	echo "[DEPLOY] Skipping snapshot deployment for a pull request."
+elif [ "$TRAVIS_BRANCH" != "master" ]; then
+	echo "[DEPLOY] Skipping snapshot deployment for branch:'$TRAVIS_BRANCH'."
+elif [ "$TRAVIS_SECURE_ENV_VARS" == "false" ]; then
+	echo "[DEPLOY] Skipping snapshot deployment due to TRAVIS_SECURE_ENV_VARS is set to '$TRAVIS_SECURE_ENV_VARS'."
+elif [ "$TRAVIS_JDK_VERSION" != "oraclejdk7" ]; then
+	echo "[DEPLOY] Skipping snapshot deployment for jdk:'$TRAVIS_JDK_VERSION'."
+else 
+	echo "[DEPLOY] Deploying snapshot for commit:'$TRAVIS_COMMIT' @ build-id:'$TRAVIS_BUILD_ID'"	
+	# create settings.xml
+	echo "<settings><servers><server><id>ossrh-snapshot</id><username>\${env.OSSRH_USER}</username><password>\${env.OSSRH_PASS}</password></server></servers></settings>" > $HOME/.m2/settings.xml	
+	# deploy
+	mvn clean deploy --settings="$HOME/.m2/settings.xml" -Dmaven.test.skip=true
+	# clean up
+	rm -f $HOME/.m2/settings.xml
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
+            <id>ossrh-snapshot</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
         <repository>


### PR DESCRIPTION
- add script for completing the deployment process of snapshots for the master repo

Note: the secure vars need to be added to see this working. These must be encrypted before adding them. 
I also suggest in creating another snapshot user which only can deploy to the snapshot repo.

See this tutorial for creating of secured vars:
* [Secure-Variables](http://docs.travis-ci.com/user/environment-variables/#Secure-Variables)
* [encryption-keys](http://docs.travis-ci.com/user/encryption-keys/)

Any comments on the change are welcome. 