### PR TITLE
Move IFunctions in separate class

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/IFunctions.java
+++ b/src/main/java/microsoft/exchange/webservices/data/IFunctions.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License
+ * Copyright (c) 2012 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package microsoft.exchange.webservices.data;
+
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * Class with re-usable function implementations.
+ */
+
+public final class IFunctions {
+
+  private IFunctions() {
+    throw new UnsupportedOperationException();
+  }
+
+  public static class ToString implements IFunction<Object, String> {
+    public static final ToString INSTANCE = new ToString();
+
+    public String func(final Object o) {
+      return String.valueOf(o);
+    }
+  }
+
+  public static class ToBoolean implements IFunction<String, Object> {
+    public static final ToBoolean INSTANCE = new ToBoolean();
+
+    public Boolean func(final String s) {
+      return Boolean.parseBoolean(s);
+    }
+  }
+
+  public static class StringToObject implements IFunction<String, Object> {
+    public static final StringToObject INSTANCE = new StringToObject();
+
+    public Object func(final String o) {
+      return o;
+    }
+  }
+
+  public static class ToUUID implements IFunction<String, Object> {
+    public static final ToUUID INSTANCE = new ToUUID();
+
+    public Object func(final String s) {
+      return UUID.fromString(s);
+    }
+  }
+
+  public static class Base64Decoder implements IFunction<String, Object> {
+    public static final Base64Decoder INSTANCE = new Base64Decoder();
+
+    public Object func(final String s) {
+      return Base64EncoderStream.decode(s);
+    }
+  }
+
+  public static class Base64Encoder implements IFunction<Object, String> {
+    public static final Base64Encoder INSTANCE = new Base64Encoder();
+
+    public String func(final Object o) {
+      return Base64EncoderStream.encode((byte[]) o);
+    }
+  }
+
+  public static class ToLowerCase implements IFunction<Object, String> {
+    public static final ToLowerCase INSTANCE = new ToLowerCase();
+
+    public String func(final Object o) {
+      return o == null ? null : o.toString().toLowerCase();
+    }
+  }
+
+  public static class DateTimeToXSDateTime implements IFunction<Object, String> {
+    public static final DateTimeToXSDateTime INSTANCE = new DateTimeToXSDateTime();
+
+    public String func(final Object o) {
+      return EwsUtilities.dateTimeToXSDateTime((Date) o);
+    }
+  }
+
+}

--- a/src/main/java/microsoft/exchange/webservices/data/MapiTypeConverter.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MapiTypeConverter.java
@@ -33,307 +33,132 @@ import java.util.*;
  */
 class MapiTypeConverter {
 
+  private static final IFunction<String, Object> DATE_TIME_PARSER = new IFunction<String, Object>() {
+    public Object func(final String s) {
+      return parseDateTime(s);
+    }
+  };
+
+  private static final IFunction<String, Object> MAPI_VALUE_PARSER = new IFunction<String, Object>() {
+    public Object func(final String s) {
+      return MapiTypeConverter.parseMapiIntegerValue(s);
+    }
+  };
+
   /**
    * The mapi type converter map.
    */
-  private static LazyMember<MapiTypeConverterMap> mapiTypeConverterMap = new
-      LazyMember<MapiTypeConverterMap>(new
-                                           ILazyMember<MapiTypeConverterMap>() {
+  private static final LazyMember<MapiTypeConverterMap> MAPI_TYPE_CONVERTER_MAP =
+      new LazyMember<MapiTypeConverterMap>(new ILazyMember<MapiTypeConverterMap>() {
+         @Override
+         public MapiTypeConverterMap createInstance() {
+           MapiTypeConverterMap map = new MapiTypeConverterMap();
 
-                                             @Override
-                                             public MapiTypeConverterMap createInstance() {
-                                               MapiTypeConverterMap map = new MapiTypeConverterMap();
+           map.put(MapiPropertyType.ApplicationTime, new MapiTypeConverterMapEntry(Double.class));
 
-                                               map.put(MapiPropertyType.ApplicationTime,
-                                                   new MapiTypeConverterMapEntry(Double.class));
+           MapiTypeConverterMapEntry mapitype = new MapiTypeConverterMapEntry(Double.class);
+           mapitype.setIsArray(true);
+           map.put(MapiPropertyType.ApplicationTimeArray, mapitype);
 
-                                               MapiTypeConverterMapEntry mapitype =
-                                                   new MapiTypeConverterMapEntry(
-                                                       Double.class);
-                                               mapitype.setIsArray(true);
-                                               map.put(MapiPropertyType.ApplicationTimeArray, mapitype);
+           mapitype = new MapiTypeConverterMapEntry(Byte[].class);
+           mapitype.setParse(IFunctions.Base64Decoder.INSTANCE);
+           mapitype.setConvertToString(IFunctions.Base64Encoder.INSTANCE);
+           map.put(MapiPropertyType.Binary, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(Byte[].class);
-                                               mapitype.setParse(new IFunction<String, Object>() {
-                                                 public Object func(String s) {
-                                                   return Base64EncoderStream.decode(s);
-                                                 }
-                                               });
-                                               mapitype
-                                                   .setConvertToString(new IFunction<Object,
-                                                       String>() {
-                                                     public String func(Object o) {
-                                                       return Base64EncoderStream
-                                                           .encode((byte[]) o);
-                                                     }
-                                                   });
-                                               map.put(MapiPropertyType.Binary, mapitype);
+           mapitype = new MapiTypeConverterMapEntry(Byte[].class);
+           mapitype.setParse(IFunctions.Base64Decoder.INSTANCE);
+           mapitype.setConvertToString(IFunctions.Base64Encoder.INSTANCE);
+           mapitype.setIsArray(true);
+           map.put(MapiPropertyType.BinaryArray, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(Byte[].class);
-                                               mapitype.setParse(new IFunction<String, Object>() {
-                                                 public Object func(String s) {
-                                                   return Base64EncoderStream.decode(s);
-                                                 }
-                                               });
-                                               mapitype
-                                                   .setConvertToString(new IFunction<Object,
-                                                       String>() {
-                                                     public String func(Object o) {
-                                                       return Base64EncoderStream
-                                                           .encode((byte[]) o);
-                                                     }
-                                                   });
-                                               mapitype.setIsArray(true);
-                                               map.put(MapiPropertyType.BinaryArray, mapitype);
+           mapitype = new MapiTypeConverterMapEntry(Boolean.class);
+           mapitype.setParse(IFunctions.ToBoolean.INSTANCE);
+           mapitype.setConvertToString(IFunctions.ToLowerCase.INSTANCE);
+           map.put(MapiPropertyType.Boolean, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(Boolean.class);
-                                               mapitype.setParse(new IFunction<String, Object>() {
-                                                 public Object func(String s) {
-                                                   return Boolean.parseBoolean(s);
-                                                 }
-                                               });
-                                               mapitype
-                                                   .setConvertToString(new IFunction<Object,
-                                                       String>() {
-                                                     public String func(Object o) {
-                                                       return o.toString().toLowerCase();
-                                                     }
-                                                   });
-                                               map.put(MapiPropertyType.Boolean, mapitype);
+           mapitype = new MapiTypeConverterMapEntry(UUID.class);
+           mapitype.setParse(IFunctions.ToUUID.INSTANCE);
+           mapitype.setConvertToString(IFunctions.ToString.INSTANCE);
+           map.put(MapiPropertyType.CLSID, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(UUID.class);
-                                               mapitype.setParse(new IFunction<String, Object>() {
-                                                 public Object func(String s) {
-                                                   return UUID.fromString(s);
-                                                 }
-                                               });
-                                               mapitype
-                                                   .setConvertToString(new IFunction<Object,
-                                                       String>() {
-                                                     public String func(Object o) {
-                                                       return o.toString();
-                                                     }
-                                                   });
-                                               map.put(MapiPropertyType.CLSID, mapitype);
+           mapitype = new MapiTypeConverterMapEntry(UUID.class);
+           mapitype.setParse(IFunctions.ToUUID.INSTANCE);
+           mapitype.setConvertToString(IFunctions.ToString.INSTANCE);
+           mapitype.setIsArray(true);
+           map.put(MapiPropertyType.CLSIDArray, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(UUID.class);
-                                               mapitype.setParse(new IFunction<String, Object>() {
-                                                 public Object func(String s) {
-                                                   return UUID.fromString(s);
-                                                 }
-                                               });
-                                               mapitype
-                                                   .setConvertToString(new IFunction<Object,
-                                                       String>() {
-                                                     public String func(Object o) {
-                                                       return o.toString();
-                                                     }
-                                                   });
-                                               mapitype.setIsArray(true);
-                                               map.put(MapiPropertyType.CLSIDArray, mapitype);
+           map.put(MapiPropertyType.Currency, new MapiTypeConverterMapEntry(Long.class));
 
-                                               map.put(MapiPropertyType.Currency,
-                                                   new MapiTypeConverterMapEntry(Long.class));
+           mapitype = new MapiTypeConverterMapEntry(Long.class);
+           mapitype.setIsArray(true);
+           map.put(MapiPropertyType.CurrencyArray, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(Long.class);
-                                               mapitype.setIsArray(true);
-                                               map.put(MapiPropertyType.CurrencyArray, mapitype);
+           map.put(MapiPropertyType.Double, new MapiTypeConverterMapEntry(Double.class));
 
-                                               map.put(MapiPropertyType.Double,
-                                                   new MapiTypeConverterMapEntry(Double.class));
+           mapitype = new MapiTypeConverterMapEntry(Double.class);
+           mapitype.setIsArray(true);
+           map.put(MapiPropertyType.DoubleArray, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(Double.class);
-                                               mapitype.setIsArray(true);
-                                               map.put(MapiPropertyType.DoubleArray, mapitype);
+           map.put(MapiPropertyType.Error, new MapiTypeConverterMapEntry(Integer.class));
+           map.put(MapiPropertyType.Float, new MapiTypeConverterMapEntry(Float.class));
 
-                                               map.put(MapiPropertyType.Error,
-                                                   new MapiTypeConverterMapEntry(Integer.class));
+           mapitype = new MapiTypeConverterMapEntry(Float.class);
+           mapitype.setIsArray(true);
+           map.put(MapiPropertyType.FloatArray, mapitype);
 
-                                               map.put(MapiPropertyType.Float,
-                                                   new MapiTypeConverterMapEntry(Float.class));
+           mapitype = new MapiTypeConverterMapEntry(Integer.class);
+           mapitype.setParse(MAPI_VALUE_PARSER);
+           map.put(MapiPropertyType.Integer, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(Float.class);
-                                               mapitype.setIsArray(true);
-                                               map.put(MapiPropertyType.FloatArray, mapitype);
+           mapitype = new MapiTypeConverterMapEntry(Integer.class);
+           mapitype.setIsArray(true);
+           map.put(MapiPropertyType.IntegerArray, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(Integer.class);
-                                               mapitype.setParse(new IFunction<String, Object>() {
-                                                 public Object func(String s) {
-                                                   return MapiTypeConverter.parseMapiIntegerValue(s);
-                                                 }
-                                               });
-                                               map.put(MapiPropertyType.Integer,
-                                                   mapitype);
+           map.put(MapiPropertyType.Long, new MapiTypeConverterMapEntry(Long.class));
 
-                                               mapitype = new MapiTypeConverterMapEntry(Integer.class);
-                                               mapitype.setIsArray(true);
-                                               map.put(MapiPropertyType.IntegerArray, mapitype);
+           mapitype = new MapiTypeConverterMapEntry(Long.class);
+           mapitype.setIsArray(true);
+           map.put(MapiPropertyType.LongArray, mapitype);
 
-                                               map.put(MapiPropertyType.Long,
-                                                   new MapiTypeConverterMapEntry(Long.class));
+           mapitype = new MapiTypeConverterMapEntry(String.class);
+           mapitype.setParse(IFunctions.StringToObject.INSTANCE);
+           map.put(MapiPropertyType.Object, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(Long.class);
-                                               mapitype.setIsArray(true);
-                                               map.put(MapiPropertyType.LongArray, mapitype);
+           mapitype = new MapiTypeConverterMapEntry(String.class);
+           mapitype.setParse(IFunctions.StringToObject.INSTANCE);
+           mapitype.setIsArray(true);
+           map.put(MapiPropertyType.ObjectArray, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(String.class);
-                                               mapitype.setParse(new IFunction<String, Object>() {
-                                                 public Object func(String s) {
-                                                   return s;
-                                                 }
-                                               });
-                                               map.put(MapiPropertyType.Object, mapitype);
+           map.put(MapiPropertyType.Short, new MapiTypeConverterMapEntry(Short.class));
 
-                                               mapitype = new MapiTypeConverterMapEntry(String.class);
-                                               mapitype.setParse(new IFunction<String, Object>() {
-                                                 public Object func(String s) {
-                                                   return s;
-                                                 }
-                                               });
-                                               mapitype.setIsArray(true);
-                                               map.put(MapiPropertyType.ObjectArray, mapitype);
+           mapitype = new MapiTypeConverterMapEntry(Short.class);
+           mapitype.setIsArray(true);
+           map.put(MapiPropertyType.ShortArray, mapitype);
 
-                                               map.put(MapiPropertyType.Short,
-                                                   new MapiTypeConverterMapEntry(Short.class));
+           mapitype = new MapiTypeConverterMapEntry(String.class);
+           mapitype.setParse(IFunctions.StringToObject.INSTANCE);
+           map.put(MapiPropertyType.String, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(Short.class);
-                                               mapitype.setIsArray(true);
-                                               map.put(MapiPropertyType.ShortArray, mapitype);
+           mapitype = new MapiTypeConverterMapEntry(String.class);
+           mapitype.setParse(IFunctions.StringToObject.INSTANCE);
+           mapitype.setIsArray(true);
+           map.put(MapiPropertyType.StringArray, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(String.class);
-                                               mapitype.setParse(new IFunction<String, Object>() {
-                                                 public Object func(String s) {
-                                                   return s;
-                                                 }
-                                               });
-                                               map.put(MapiPropertyType.String, mapitype);
+           mapitype = new MapiTypeConverterMapEntry(Date.class);
+           mapitype.setParse(DATE_TIME_PARSER);
+           mapitype.setConvertToString(IFunctions.DateTimeToXSDateTime.INSTANCE);
+           map.put(MapiPropertyType.SystemTime, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(String.class);
-                                               mapitype.setParse(new IFunction<String, Object>() {
-                                                 public Object func(String s) {
-                                                   return s;
-                                                 }
-                                               });
-                                               mapitype.setIsArray(true);
-                                               map.put(MapiPropertyType.StringArray, mapitype);
+           mapitype = new MapiTypeConverterMapEntry(Date.class);
+           mapitype.setParse(DATE_TIME_PARSER);
+           mapitype.setConvertToString(IFunctions.DateTimeToXSDateTime.INSTANCE);
+           mapitype.setIsArray(true);
+           map.put(MapiPropertyType.SystemTimeArray, mapitype);
 
-                                               mapitype = new MapiTypeConverterMapEntry(Date.class);
-                                               mapitype.setParse(new IFunction<String, Object>() {
-                                                 public Object func(String s) {
-                                                   String utcPattern = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-                                                   Date dt = null;
-                                                   String errMsg = String
-                                                       .format(
-                                                           "Date String %s not in " +
-                                                               "valid UTC/local format",
-                                                           s);
-                                                   DateFormat utcFormatter = new SimpleDateFormat(
-                                                       utcPattern);
-                                                   if (s.endsWith("Z")) {
-                                                     try {
-                                                       dt = utcFormatter.parse(s);
-                                                     } catch (ParseException e) {
-                                                       s = s.substring(0, 10) + "T12:00:00Z";
-                                                       try {
-                                                         dt = utcFormatter.parse(s);
-                                                       } catch (ParseException e1) {
-                                                         e.printStackTrace();
-                                                         throw new IllegalArgumentException(
-                                                             errMsg, e);
-                                                       }
-                                                     }
-                                                   } else if (s.endsWith("z")) {
-                                                     // String in UTC format yyyy-MM-ddTHH:mm:ssZ
-                                                     utcFormatter = new SimpleDateFormat(
-                                                         "yyyy-MM-dd'T'HH:mm:ss'z'");
-                                                     try {
-                                                       dt = utcFormatter.parse(s);
-                                                     } catch (ParseException e) {
-                                                       throw new IllegalArgumentException(e);
-                                                     }
-                                                   } else {
-                                                     utcFormatter = new SimpleDateFormat(
-                                                         "yyyy-MM-dd'T'HH:mm:ss");
-                                                     try {
-                                                       dt = utcFormatter.parse(s);
-                                                     } catch (ParseException e) {
-                                                       throw new IllegalArgumentException(e);
-                                                     }
-                                                   }
-                                                   return dt;
-                                                 }
-                                               });
-                                               mapitype
-                                                   .setConvertToString(new IFunction<Object,
-                                                       String>() {
-                                                     public String func(Object o) {
-                                                       return EwsUtilities
-                                                           .dateTimeToXSDateTime((Date) o);
-                                                     }
-                                                   });
-                                               map.put(MapiPropertyType.SystemTime, mapitype);
+           return map;
+         }
+  });
 
-                                               mapitype = new MapiTypeConverterMapEntry(Date.class);
-                                               mapitype.setParse(new IFunction<String, Object>() {
-                                                 public Object func(String s) {
-                                                   String utcPattern = "yyyy-MM-dd'T'HH:mm:ss'Z'";
-                                                   Date dt = null;
-                                                   String errMsg = String
-                                                       .format(
-                                                           "Date String %s not in " +
-                                                               "valid UTC/local format",
-                                                           s);
-                                                   DateFormat utcFormatter = new SimpleDateFormat(
-                                                       utcPattern);
-                                                   if (s.endsWith("Z")) {
-                                                     try {
-                                                       dt = utcFormatter.parse(s);
-                                                     } catch (ParseException e) {
-                                                       s = s.substring(0, 10) + "T12:00:00Z";
-                                                       try {
-                                                         dt = utcFormatter.parse(s);
-                                                       } catch (ParseException e1) {
-                                                         e.printStackTrace();
-                                                         throw new IllegalArgumentException(
-                                                             errMsg, e);
-                                                       }
-                                                     }
-                                                   } else if (s.endsWith("z")) {
-                                                     // String in UTC format yyyy-MM-ddTHH:mm:ssZ
-                                                     utcFormatter = new SimpleDateFormat(
-                                                         "yyyy-MM-dd'T'HH:mm:ss'z'");
-                                                     try {
-                                                       dt = utcFormatter.parse(s);
-                                                     } catch (ParseException e) {
-                                                       throw new IllegalArgumentException(e);
-                                                     }
-                                                   } else {
-                                                     utcFormatter = new SimpleDateFormat(
-                                                         "yyyy-MM-dd'T'HH:mm:ss");
-                                                     try {
-                                                       dt = utcFormatter.parse(s);
-                                                     } catch (ParseException e) {
-                                                       throw new IllegalArgumentException(e);
-                                                     }
-                                                   }
-                                                   return dt;
-                                                 }
-                                               });
-                                               mapitype
-                                                   .setConvertToString(new IFunction<Object,
-                                                       String>() {
-                                                     public String func(Object o) {
-                                                       return EwsUtilities
-                                                           .dateTimeToXSDateTime((Date) o);
-                                                     }
-                                                   });
-                                               mapitype.setIsArray(true);
-                                               map.put(MapiPropertyType.SystemTimeArray, mapitype);
-
-                                               return map;
-                                             }
-
-                                           });
 
   /**
    * Converts the string list to array.
@@ -445,6 +270,46 @@ class MapiTypeConverter {
   protected static Map<MapiPropertyType, MapiTypeConverterMapEntry>
   getMapiTypeConverterMap() {
 
-    return mapiTypeConverterMap.getMember();
+    return MAPI_TYPE_CONVERTER_MAP.getMember();
   }
+
+
+  private static Object parseDateTime(String s) {
+    String utcPattern = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+    String errMsg = String.format("Date String %s not in " + "valid UTC/local format", s);
+    DateFormat utcFormatter = new SimpleDateFormat(utcPattern);
+    Date dt;
+
+    if (s.endsWith("Z")) {
+      try {
+        dt = utcFormatter.parse(s);
+      } catch (ParseException e) {
+        s = s.substring(0, 10) + "T12:00:00Z";
+        try {
+          dt = utcFormatter.parse(s);
+        } catch (ParseException e1) {
+          e.printStackTrace();
+          throw new IllegalArgumentException(
+              errMsg, e);
+        }
+      }
+    } else if (s.endsWith("z")) {
+      // String in UTC format yyyy-MM-ddTHH:mm:ssZ
+      utcFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'z'");
+      try {
+        dt = utcFormatter.parse(s);
+      } catch (ParseException e) {
+        throw new IllegalArgumentException(e);
+      }
+    } else {
+      utcFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+      try {
+        dt = utcFormatter.parse(s);
+      } catch (ParseException e) {
+        throw new IllegalArgumentException(e);
+      }
+    }
+    return dt;
+  }
+
 }

--- a/src/main/java/microsoft/exchange/webservices/data/MapiTypeConverterMapEntry.java
+++ b/src/main/java/microsoft/exchange/webservices/data/MapiTypeConverterMapEntry.java
@@ -99,17 +99,8 @@ class MapiTypeConverterMapEntry {
         String.format("No default value entry for type {0}", type.getName()));
 
     this.type = type;
-    this.convertToString = new IFunction<Object, String>() {
-      public String func(Object o) {
-        return String.valueOf(o);
-      }
-    };
-
-    this.parse = new IFunction<String, Object>() {
-      public Object func(String o) {
-        return o;
-      }
-    };
+    this.convertToString = IFunctions.ToString.INSTANCE;
+    this.parse = IFunctions.StringToObject.INSTANCE;
   }
 
   /**

--- a/src/test/java/microsoft/exchange/webservices/data/IFunctionsTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/IFunctionsTest.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License
+ * Copyright (c) 2012 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package microsoft.exchange.webservices.data;
+
+import org.apache.commons.codec.binary.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Date;
+import java.util.UUID;
+
+@RunWith(JUnit4.class)
+public class IFunctionsTest {
+
+  @Test
+  public void testToString() {
+    final IFunctions.ToString f = IFunctions.ToString.INSTANCE;
+    Assert.assertEquals("null", f.func(null));
+    Assert.assertEquals("", f.func(""));
+    Assert.assertEquals("1", f.func(1));
+  }
+
+  @Test
+  public void testToBoolean() {
+    final IFunctions.ToBoolean f = IFunctions.ToBoolean.INSTANCE;
+    Assert.assertFalse(f.func(null));
+    Assert.assertFalse(f.func(""));
+    Assert.assertFalse(f.func("false"));
+    Assert.assertTrue(f.func("true"));
+  }
+
+  @Test
+  public void testStringToObject() {
+    final IFunctions.StringToObject f = IFunctions.StringToObject.INSTANCE;
+    Assert.assertNull(f.func(null));
+    Assert.assertEquals("", f.func(""));
+  }
+
+  @Test
+  public void testToUUID() {
+    final IFunctions.ToUUID f = IFunctions.ToUUID.INSTANCE;
+    try {
+      Assert.assertNull(f.func(null));
+    } catch (final Throwable ex) {
+      final UUID uuid = UUID.randomUUID();
+      Assert.assertEquals(uuid, f.func(uuid.toString()));
+    }
+  }
+
+  @Test
+  public void testBase64Decoder() {
+    final String value = "123";
+    final IFunctions.Base64Decoder f = IFunctions.Base64Decoder.INSTANCE;
+    Assert.assertArrayEquals(Base64EncoderStream.decode(value), (byte[]) f.func(value));
+  }
+
+  @Test
+  public void testBase64Encoder() {
+    final byte[] value = StringUtils.getBytesUtf8("123");
+    final IFunctions.Base64Encoder f = IFunctions.Base64Encoder.INSTANCE;
+    Assert.assertEquals(Base64EncoderStream.encode(value), f.func(value));
+  }
+
+  @Test
+  public void testToLowerCase() {
+    final IFunctions.ToLowerCase f = IFunctions.ToLowerCase.INSTANCE;
+    Assert.assertNull(f.func(null));
+    Assert.assertEquals("", f.func(""));
+    Assert.assertEquals("abc", f.func("AbC"));
+  }
+
+  @Test
+  public void testDateTimeToXSDateTime() {
+    final IFunctions.DateTimeToXSDateTime f = IFunctions.DateTimeToXSDateTime.INSTANCE;
+    final Date value = new Date();
+    Assert.assertEquals(EwsUtilities.dateTimeToXSDateTime(value), f.func(value));
+  }
+
+}


### PR DESCRIPTION
It allows to:
* remove some duplicated code
* re-use thread-safe instances of IFunction interface

I also added unit tests for this changes.