### PR TITLE
sign artifact with gpg

### DIFF
--- a/deploy_snapshot.sh
+++ b/deploy_snapshot.sh
@@ -34,9 +34,15 @@ elif [ "$TRAVIS_JDK_VERSION" != "oraclejdk7" ]; then
 else 
 	echo "[DEPLOY] Deploying snapshot for commit:'$TRAVIS_COMMIT' @ build-id:'$TRAVIS_BUILD_ID'"	
 	# create settings.xml
-	echo "<settings><servers><server><id>ossrh-snapshot</id><username>\${env.OSSRH_USER}</username><password>\${env.OSSRH_PASS}</password></server></servers></settings>" > $HOME/.m2/settings.xml	
+	echo "<settings><servers><server><id>ossrh-snapshot</id><username>${OSSRH_USER}</username><password>${OSSRH_PASS}</password></server></servers></settings>" > $HOME/.m2/settings.xml
 	# deploy
-	mvn clean deploy --settings="$HOME/.m2/settings.xml" -Dmaven.test.skip=true
+	if [ -z "${GPG_PASSPHRASE+xxx}" ]; then
+	    echo "[INFO] Deploying unsigned artifacts"
+            mvn clean deploy --settings="$HOME/.m2/settings.xml" -Dmaven.test.skip=true
+        else
+            echo "[INFO] Deploying signed artifacts"
+            mvn clean deploy --settings="$HOME/.m2/settings.xml" -Dmaven.test.skip=true -Dgpg.passphrase=$GPG_PASSPHRASE
+        fi
 	# clean up
 	rm -f $HOME/.m2/settings.xml
 fi

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,32 @@
                 <javadoc.doclint.param>-Xdoclint:none</javadoc.doclint.param>
             </properties>
         </profile>
+        <profile>
+            <id>release-sign-artifacts</id>
+            <activation>
+                <property>
+                    <name>gpg.passphrase</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <licenses>


### PR DESCRIPTION
- sign all artifacts for deployment with gpg
- artifacts will only be sign if -Dparameter with passphrase is set

The following will **not** track gpg signature process (this will allow every user to make local builds):
```xml
   mvn clean install
   mvn clean deploy
```

The following will track gpg signature process:
```xml
   mvn clean install -Dgpg.passphrase=myverysupersecretpassphrase
   mvn clean deploy -Dgpg.passphrase=myverysupersecretpassphrase
```

* [tutorial on gpg](http://blog.sonatype.com/2010/01/how-to-generate-pgp-signatures-with-maven/#.VP9VPvmG-3g)