### PR TITLE
Fix issue #245: close stream after reading file content

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/ExchangeService.java
@@ -1336,8 +1336,7 @@ public final class ExchangeService extends ExchangeServiceBase implements
 
     Iterator<Attachment> it = attachments.iterator();
     while (it.hasNext()) {
-      ((ArrayList<Attachment>) request.getAttachments()).add(it.next());
-
+      request.getAttachments().add(it.next());
     }
     request.setBodyType(bodyType);
 

--- a/src/main/java/microsoft/exchange/webservices/data/FileAttachment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/FileAttachment.java
@@ -214,12 +214,17 @@ public final class FileAttachment extends Attachment {
    */
   public void load(String fileName) throws Exception {
     File fileStream = new File(fileName);
-    FileOutputStream fos = new FileOutputStream(fileStream);
-    this.loadToStream = fos;
+
     try {
+      this.loadToStream = new FileOutputStream(fileStream);
       this.load();
-    } finally {
       this.loadToStream.flush();
+    } finally {
+      try {
+        this.loadToStream.close();
+      } catch(Exception e) {
+        //ignore exception on close
+      }
       this.loadToStream = null;
     }
 


### PR DESCRIPTION
Fix issue #245: close stream after reading file content
avoid useless downcast in ExchangeService.getAttachments method.