### PR TITLE
Remove unnecessary type casting

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/request/DelegateManagementRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/DelegateManagementRequestBase.java
@@ -107,7 +107,7 @@ abstract class DelegateManagementRequestBase<TResponse extends DelegateManagemen
    * @throws Exception the exception
    */
   public TResponse execute() throws Exception {
-    TResponse serviceResponse = (TResponse) this.internalExecute();
+    TResponse serviceResponse = internalExecute();
     serviceResponse.throwIfNecessary();
     return serviceResponse;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/DisconnectPhoneCallRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/DisconnectPhoneCallRequest.java
@@ -114,8 +114,7 @@ public final class DisconnectPhoneCallRequest extends SimpleServiceRequestBase<S
    * @throws Exception the exception
    */
   public ServiceResponse execute() throws Exception {
-    ServiceResponse serviceResponse = (ServiceResponse) this
-        .internalExecute();
+    ServiceResponse serviceResponse = internalExecute();
     serviceResponse.throwIfNecessary();
     return serviceResponse;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/FindConversationRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/FindConversationRequest.java
@@ -26,8 +26,8 @@ package microsoft.exchange.webservices.data.core.request;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlWriter;
 import microsoft.exchange.webservices.data.core.ExchangeService;
-import microsoft.exchange.webservices.data.core.response.FindConversationResponse;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
+import microsoft.exchange.webservices.data.core.response.FindConversationResponse;
 import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceLocalException;
@@ -195,8 +195,7 @@ public final class FindConversationRequest extends SimpleServiceRequestBase<Find
    */
   public FindConversationResponse execute()
       throws ServiceLocalException, Exception {
-    FindConversationResponse serviceResponse =
-        (FindConversationResponse) this.internalExecute();
+    FindConversationResponse serviceResponse = internalExecute();
     serviceResponse.throwIfNecessary();
     return serviceResponse;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetInboxRulesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetInboxRulesRequest.java
@@ -140,8 +140,7 @@ public final class GetInboxRulesRequest extends SimpleServiceRequestBase<GetInbo
    */
   public GetInboxRulesResponse execute()
       throws ServiceLocalException, Exception {
-    GetInboxRulesResponse serviceResponse =
-        (GetInboxRulesResponse) this.internalExecute();
+    GetInboxRulesResponse serviceResponse = internalExecute();
     serviceResponse.throwIfNecessary();
     return serviceResponse;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetPasswordExpirationDateRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetPasswordExpirationDateRequest.java
@@ -26,8 +26,8 @@ package microsoft.exchange.webservices.data.core.request;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlWriter;
 import microsoft.exchange.webservices.data.core.ExchangeService;
-import microsoft.exchange.webservices.data.core.response.GetPasswordExpirationDateResponse;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
+import microsoft.exchange.webservices.data.core.response.GetPasswordExpirationDateResponse;
 import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceLocalException;
@@ -98,8 +98,7 @@ public final class GetPasswordExpirationDateRequest extends SimpleServiceRequest
    * @return Service response.
    */
   public GetPasswordExpirationDateResponse execute() throws Exception {
-    GetPasswordExpirationDateResponse serviceResponse =
-        (GetPasswordExpirationDateResponse) this.internalExecute();
+    GetPasswordExpirationDateResponse serviceResponse = internalExecute();
     serviceResponse.throwIfNecessary();
     return serviceResponse;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetPhoneCallRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetPhoneCallRequest.java
@@ -113,8 +113,7 @@ public final class GetPhoneCallRequest extends SimpleServiceRequestBase<GetPhone
    * @throws Exception the exception
    */
   public GetPhoneCallResponse execute() throws Exception {
-    GetPhoneCallResponse serviceResponse = (GetPhoneCallResponse) this
-        .internalExecute();
+    GetPhoneCallResponse serviceResponse = internalExecute();
     serviceResponse.throwIfNecessary();
     return serviceResponse;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetRoomListsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetRoomListsRequest.java
@@ -103,8 +103,7 @@ public final class GetRoomListsRequest extends SimpleServiceRequestBase<GetRoomL
    * @throws Exception the exception
    */
   public GetRoomListsResponse execute() throws Exception {
-    GetRoomListsResponse serviceResponse = (GetRoomListsResponse) this
-        .internalExecute();
+    GetRoomListsResponse serviceResponse = internalExecute();
     serviceResponse.throwIfNecessary();
     return serviceResponse;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetRoomsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetRoomsRequest.java
@@ -108,8 +108,7 @@ public final class GetRoomsRequest extends SimpleServiceRequestBase<GetRoomsResp
    * @throws Exception the exception
    */
   public GetRoomsResponse execute() throws Exception {
-    GetRoomsResponse serviceResponse = (GetRoomsResponse) this
-        .internalExecute();
+    GetRoomsResponse serviceResponse = internalExecute();
     serviceResponse.throwIfNecessary();
     return serviceResponse;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetUserAvailabilityRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetUserAvailabilityRequest.java
@@ -242,7 +242,7 @@ public final class GetUserAvailabilityRequest extends SimpleServiceRequestBase<G
    * @throws Exception the exception
    */
   public GetUserAvailabilityResults execute() throws Exception {
-    return (GetUserAvailabilityResults) this.internalExecute();
+    return internalExecute();
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetUserOofSettingsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetUserOofSettingsRequest.java
@@ -150,9 +150,7 @@ public final class GetUserOofSettingsRequest extends SimpleServiceRequestBase<Ge
    * @throws Exception the exception
    */
   public GetUserOofSettingsResponse execute() throws Exception {
-    GetUserOofSettingsResponse serviceResponse =
-        (GetUserOofSettingsResponse) this
-            .internalExecute();
+    GetUserOofSettingsResponse serviceResponse = internalExecute();
     serviceResponse.throwIfNecessary();
     return serviceResponse;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/MultiResponseServiceRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/MultiResponseServiceRequest.java
@@ -26,9 +26,9 @@ package microsoft.exchange.webservices.data.core.request;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.EwsUtilities;
 import microsoft.exchange.webservices.data.core.ExchangeService;
+import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.core.response.ServiceResponse;
 import microsoft.exchange.webservices.data.core.response.ServiceResponseCollection;
-import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.enumeration.ServiceErrorHandling;
 import microsoft.exchange.webservices.data.enumeration.ServiceResult;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
@@ -155,9 +155,7 @@ public abstract class MultiResponseServiceRequest<TResponse extends ServiceRespo
    * @throws Exception the exception
    */
   public ServiceResponseCollection<TResponse> execute() throws Exception {
-    ServiceResponseCollection<TResponse> serviceResponses =
-        (ServiceResponseCollection<TResponse>) this
-            .internalExecute();
+    ServiceResponseCollection<TResponse> serviceResponses = internalExecute();
 
     if (this.errorHandlingMode == ServiceErrorHandling.ThrowOnError) {
       EwsUtilities.EwsAssert(serviceResponses.getCount() == 1, "MultiResponseServiceRequest.Execute",
@@ -177,8 +175,7 @@ public abstract class MultiResponseServiceRequest<TResponse extends ServiceRespo
    * @return Service response collection.
    */
   public ServiceResponseCollection<TResponse> endExecute(IAsyncResult asyncResult) throws Exception {
-    ServiceResponseCollection<TResponse> serviceResponses =
-        (ServiceResponseCollection<TResponse>) this.endInternalExecute(asyncResult);
+    ServiceResponseCollection<TResponse> serviceResponses = endInternalExecute(asyncResult);
 
     if (this.errorHandlingMode == ServiceErrorHandling.ThrowOnError) {
       EwsUtilities.EwsAssert(

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/PlayOnPhoneRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/PlayOnPhoneRequest.java
@@ -26,8 +26,8 @@ package microsoft.exchange.webservices.data.core.request;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlWriter;
 import microsoft.exchange.webservices.data.core.ExchangeService;
-import microsoft.exchange.webservices.data.core.response.PlayOnPhoneResponse;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
+import microsoft.exchange.webservices.data.core.response.PlayOnPhoneResponse;
 import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.property.complex.ItemId;
@@ -122,8 +122,7 @@ public final class PlayOnPhoneRequest extends SimpleServiceRequestBase<PlayOnPho
    * @throws Exception the exception
    */
   public PlayOnPhoneResponse execute() throws Exception {
-    PlayOnPhoneResponse serviceResponse = (PlayOnPhoneResponse) this
-        .internalExecute();
+    PlayOnPhoneResponse serviceResponse = internalExecute();
     serviceResponse.throwIfNecessary();
     return serviceResponse;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/SetUserOofSettingsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/SetUserOofSettingsRequest.java
@@ -137,8 +137,7 @@ public final class SetUserOofSettingsRequest extends SimpleServiceRequestBase<Se
    * @throws Exception the exception
    */
   public ServiceResponse execute() throws Exception {
-    ServiceResponse serviceResponse = (ServiceResponse) this
-        .internalExecute();
+    ServiceResponse serviceResponse = internalExecute();
     serviceResponse.throwIfNecessary();
     return serviceResponse;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/SimpleServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/SimpleServiceRequestBase.java
@@ -70,7 +70,7 @@ public abstract class SimpleServiceRequestBase<T> extends ServiceRequestBase<T> 
     } catch (IOException ex) {
       // Wrap exception.
       throw new ServiceRequestException(String.
-          format("The request failed. %s", ex.getMessage(), ex));
+          format("The request failed. %s", ex.getMessage()), ex);
     } catch (Exception e) {
       if (response != null) {
         this.getService().processHttpResponseHeaders(TraceFlags.

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/UpdateInboxRulesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/UpdateInboxRulesRequest.java
@@ -27,8 +27,8 @@ import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlWriter;
 import microsoft.exchange.webservices.data.core.EwsUtilities;
 import microsoft.exchange.webservices.data.core.ExchangeService;
-import microsoft.exchange.webservices.data.core.response.UpdateInboxRulesResponse;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
+import microsoft.exchange.webservices.data.core.response.UpdateInboxRulesResponse;
 import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.ServiceResult;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
@@ -166,8 +166,7 @@ public final class UpdateInboxRulesRequest extends SimpleServiceRequestBase<Upda
    */
   public UpdateInboxRulesResponse execute()
       throws ServiceLocalException, Exception {
-    UpdateInboxRulesResponse serviceResponse =
-        (UpdateInboxRulesResponse) this.internalExecute();
+    UpdateInboxRulesResponse serviceResponse = internalExecute();
     if (serviceResponse.getResult() == ServiceResult.Error) {
       throw new UpdateInboxRulesException(serviceResponse,
           this.inboxRuleOperations);

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/ExecuteDiagnosticMethodResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/ExecuteDiagnosticMethodResponse.java
@@ -27,8 +27,8 @@ import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.EwsUtilities;
 import microsoft.exchange.webservices.data.core.ExchangeService;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
-import microsoft.exchange.webservices.data.security.XmlNodeType;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
+import microsoft.exchange.webservices.data.security.XmlNodeType;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -41,6 +41,7 @@ import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.Namespace;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
+
 import java.util.Iterator;
 
 
@@ -118,7 +119,7 @@ public final class ExecuteDiagnosticMethodResponse extends ServiceResponse {
         Iterator<Attribute> ite = ele.getAttributes();
 
         while (ite.hasNext()) {
-          Attribute attr = (Attribute) ite.next();
+          Attribute attr = ite.next();
           element.setAttribute(attr.getName().getLocalPart(),
               attr.getValue());
         }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/folder/Folder.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/folder/Folder.java
@@ -620,9 +620,8 @@ public class Folder extends ServiceObject {
    */
   public FolderId getId() {
     try {
-      return (FolderId) (this.getPropertyBag()
-          .getObjectFromPropertyDefinition(this
-              .getIdPropertyDefinition()));
+      return getPropertyBag().getObjectFromPropertyDefinition(
+          getIdPropertyDefinition());
     } catch (ServiceLocalException e) {
       e.printStackTrace();
       return null;
@@ -636,8 +635,8 @@ public class Folder extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public FolderId getParentFolderId() throws ServiceLocalException {
-    return (FolderId) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(FolderSchema.ParentFolderId);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        FolderSchema.ParentFolderId);
   }
 
   /**
@@ -661,9 +660,8 @@ public class Folder extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public String getDisplayName() throws ServiceLocalException {
-    return (String) (this.getPropertyBag()
-        .getObjectFromPropertyDefinition(FolderSchema.DisplayName));
-
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        FolderSchema.DisplayName);
   }
 
   /**
@@ -684,7 +682,7 @@ public class Folder extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public String getFolderClass() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         FolderSchema.FolderClass);
   }
 
@@ -722,9 +720,8 @@ public class Folder extends ServiceObject {
   // changed the name of method as another method with same name exists
   public ExtendedPropertyCollection getExtendedPropertiesForService()
       throws ServiceLocalException {
-    return (ExtendedPropertyCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            ServiceObjectSchema.extendedProperties);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ServiceObjectSchema.extendedProperties);
   }
 
   /**
@@ -736,9 +733,8 @@ public class Folder extends ServiceObject {
    */
   public ManagedFolderInformation getManagedFolderInformation()
       throws ServiceLocalException {
-    return (ManagedFolderInformation) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            FolderSchema.ManagedFolderInformation);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        FolderSchema.ManagedFolderInformation);
   }
 
   /**
@@ -749,8 +745,8 @@ public class Folder extends ServiceObject {
    * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
    */
   public EnumSet<EffectiveRights> getEffectiveRights() throws ServiceLocalException {
-    return (EnumSet<EffectiveRights>) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(FolderSchema.EffectiveRights);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        FolderSchema.EffectiveRights);
   }
 
   /**
@@ -761,8 +757,8 @@ public class Folder extends ServiceObject {
    */
   public FolderPermissionCollection getPermissions()
       throws ServiceLocalException {
-    return (FolderPermissionCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(FolderSchema.Permissions);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        FolderSchema.Permissions);
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/folder/SearchFolder.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/folder/SearchFolder.java
@@ -154,9 +154,8 @@ public class SearchFolder extends Folder {
    * @throws Exception the exception
    */
   public SearchFolderParameters getSearchParameters() throws Exception {
-    return (SearchFolderParameters) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            SearchFolderSchema.SearchParameters);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        SearchFolderSchema.SearchParameters);
   }
 
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/Appointment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/Appointment.java
@@ -615,7 +615,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Date getStart() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.Start);
   }
 
@@ -637,7 +637,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Date getEnd() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.End);
   }
 
@@ -659,7 +659,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
    */
   public Date getOriginalStart() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.OriginalStart);
   }
 
@@ -671,7 +671,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsAllDayEvent() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.IsAllDayEvent);
   }
 
@@ -695,9 +695,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    */
   public LegacyFreeBusyStatus getLegacyFreeBusyStatus()
       throws ServiceLocalException {
-    return (LegacyFreeBusyStatus) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.LegacyFreeBusyStatus);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.LegacyFreeBusyStatus);
   }
 
   /**
@@ -719,7 +718,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public String getLocation() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.Location);
   }
 
@@ -744,7 +743,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public String getWhen() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.When);
   }
 
@@ -755,7 +754,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsMeeting() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.IsMeeting);
   }
 
@@ -766,7 +765,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsCancelled() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.IsCancelled);
   }
 
@@ -777,7 +776,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsRecurring() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.IsRecurring);
   }
 
@@ -789,7 +788,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getMeetingRequestWasSent() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.MeetingRequestWasSent);
   }
 
@@ -801,7 +800,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsResponseRequested() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.IsResponseRequested);
   }
 
@@ -823,9 +822,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public AppointmentType getAppointmentType() throws ServiceLocalException {
-    return (AppointmentType) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.AppointmentType);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.AppointmentType);
   }
 
   /**
@@ -837,9 +835,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    */
   public MeetingResponseType getMyResponseType()
       throws ServiceLocalException {
-    return (MeetingResponseType) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.MyResponseType);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.MyResponseType);
   }
 
   /**
@@ -851,8 +848,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public EmailAddress getOrganizer() throws ServiceLocalException {
-    return (EmailAddress) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(AppointmentSchema.Organizer);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.Organizer);
   }
 
   /**
@@ -863,9 +860,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    */
   public AttendeeCollection getRequiredAttendees()
       throws ServiceLocalException {
-    return (AttendeeCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.RequiredAttendees);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.RequiredAttendees);
   }
 
   /**
@@ -876,9 +872,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    */
   public AttendeeCollection getOptionalAttendees()
       throws ServiceLocalException {
-    return (AttendeeCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.OptionalAttendees);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.OptionalAttendees);
   }
 
   /**
@@ -888,8 +883,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public AttendeeCollection getResources() throws ServiceLocalException {
-    return (AttendeeCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(AppointmentSchema.Resources);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.Resources);
   }
 
   /**
@@ -900,7 +895,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Integer getConflictingMeetingCount() throws ServiceLocalException {
-    return (Integer) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.ConflictingMeetingCount);
   }
 
@@ -912,7 +907,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Integer getAdjacentMeetingCount() throws ServiceLocalException {
-    return (Integer) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.AdjacentMeetingCount);
   }
 
@@ -925,9 +920,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    */
   public ItemCollection<Appointment> getConflictingMeetings()
       throws ServiceLocalException {
-    return (ItemCollection<Appointment>) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.ConflictingMeetings);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.ConflictingMeetings);
   }
 
   /**
@@ -939,8 +933,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    */
   public ItemCollection<Appointment> getAdjacentMeetings()
       throws ServiceLocalException {
-    return (ItemCollection<Appointment>) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
             AppointmentSchema.AdjacentMeetings);
   }
 
@@ -951,7 +944,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public TimeSpan getDuration() throws ServiceLocalException {
-    return (TimeSpan) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.Duration);
   }
 
@@ -962,7 +955,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public String getTimeZone() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.TimeZone);
   }
 
@@ -973,7 +966,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Date getAppointmentReplyTime() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.AppointmentReplyTime);
   }
 
@@ -984,7 +977,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Integer getAppointmentSequenceNumber() throws ServiceLocalException {
-    return (Integer) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.AppointmentSequenceNumber);
   }
 
@@ -995,7 +988,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Integer getAppointmentState() throws ServiceLocalException {
-    return (Integer) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.AppointmentState);
   }
 
@@ -1008,8 +1001,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Recurrence getRecurrence() throws ServiceLocalException {
-    return (Recurrence) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(AppointmentSchema.Recurrence);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.Recurrence);
   }
 
   /**
@@ -1035,9 +1028,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public OccurrenceInfo getFirstOccurrence() throws ServiceLocalException {
-    return (OccurrenceInfo) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.FirstOccurrence);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+          AppointmentSchema.FirstOccurrence);
   }
 
   /**
@@ -1047,9 +1039,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public OccurrenceInfo getLastOccurrence() throws ServiceLocalException {
-    return (OccurrenceInfo) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.LastOccurrence);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+          AppointmentSchema.LastOccurrence);
   }
 
   /**
@@ -1060,9 +1051,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    */
   public OccurrenceInfoCollection getModifiedOccurrences()
       throws ServiceLocalException {
-    return (OccurrenceInfoCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.ModifiedOccurrences);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+          AppointmentSchema.ModifiedOccurrences);
   }
 
   /**
@@ -1073,9 +1063,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    */
   public DeletedOccurrenceInfoCollection getDeletedOccurrences()
       throws ServiceLocalException {
-    return (DeletedOccurrenceInfoCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.DeletedOccurrences);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+          AppointmentSchema.DeletedOccurrences);
   }
 
   /**
@@ -1085,9 +1074,8 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public TimeZoneDefinition getStartTimeZone() throws ServiceLocalException {
-    return (TimeZoneDefinition) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.StartTimeZone);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+          AppointmentSchema.StartTimeZone);
   }
 
   /**
@@ -1109,7 +1097,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public TimeZoneDefinition getEndTimeZone() throws ServiceLocalException {
-    return (TimeZoneDefinition) this.getPropertyBag()
+    return getPropertyBag()
         .getObjectFromPropertyDefinition(AppointmentSchema.EndTimeZone);
   }
 
@@ -1133,7 +1121,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Integer getConferenceType() throws ServiceLocalException {
-    return (Integer) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.ConferenceType);
   }
 
@@ -1156,7 +1144,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getAllowNewTimeProposal() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.AllowNewTimeProposal);
   }
 
@@ -1178,7 +1166,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsOnlineMeeting() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.IsOnlineMeeting);
   }
 
@@ -1201,7 +1189,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public String getMeetingWorkspaceUrl() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.MeetingWorkspaceUrl);
   }
 
@@ -1223,7 +1211,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public String getNetShowUrl() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.NetShowUrl);
   }
 
@@ -1245,7 +1233,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public String getICalUid() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.ICalUid);
   }
 
@@ -1267,7 +1255,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Date getICalRecurrenceId() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.ICalRecurrenceId);
   }
 
@@ -1278,7 +1266,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
    * @throws ServiceLocalException the service local exception
    */
   public Date getICalDateTimeStamp() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.ICalDateTimeStamp);
   }
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/Contact.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/Contact.java
@@ -279,7 +279,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getFileAs() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.FileAs);
 
   }
@@ -303,8 +303,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public FileAsMapping getFileAsMapping() throws ServiceLocalException {
-    return (FileAsMapping) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ContactSchema.FileAsMapping);
+    return getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.FileAsMapping);
   }
 
   /**
@@ -325,7 +324,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getDisplayName() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.DisplayName);
   }
 
@@ -347,7 +346,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getGivenName() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.GivenName);
   }
 
@@ -369,7 +368,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getInitials() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.Initials);
   }
 
@@ -391,7 +390,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getMiddleName() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.MiddleName);
   }
 
@@ -413,7 +412,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getNickName() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.NickName);
   }
 
@@ -435,7 +434,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public CompleteName getCompleteName() throws ServiceLocalException {
-    return (CompleteName) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.CompleteName);
   }
 
@@ -446,7 +445,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getCompanyName() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.CompanyName);
   }
 
@@ -471,8 +470,7 @@ public class Contact extends Item {
    */
   public EmailAddressDictionary getEmailAddresses()
       throws ServiceLocalException {
-    return (EmailAddressDictionary) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ContactSchema.EmailAddresses);
+    return getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.EmailAddresses);
   }
 
   /**
@@ -485,9 +483,7 @@ public class Contact extends Item {
    */
   public PhysicalAddressDictionary getPhysicalAddresses()
       throws ServiceLocalException {
-    return (PhysicalAddressDictionary) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            ContactSchema.PhysicalAddresses);
+    return getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.PhysicalAddresses);
   }
 
   /**
@@ -500,7 +496,7 @@ public class Contact extends Item {
    */
   public PhoneNumberDictionary getPhoneNumbers()
       throws ServiceLocalException {
-    return (PhoneNumberDictionary) this.getPropertyBag()
+    return getPropertyBag()
         .getObjectFromPropertyDefinition(ContactSchema.PhoneNumbers);
   }
 
@@ -511,7 +507,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getAssistantName() throws ServiceLocalException {
-    return (String) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.AssistantName);
   }
 
@@ -533,7 +529,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Date getBirthday() throws ServiceLocalException {
-    return (Date) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.Birthday);
 
   }
@@ -556,7 +552,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getBusinessHomePage() throws ServiceLocalException {
-    return (String) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.BusinessHomePage);
 
   }
@@ -579,9 +575,8 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public StringList getChildren() throws ServiceLocalException {
-    return (StringList) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.Children);
-
   }
 
   /**
@@ -602,9 +597,8 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public StringList getCompanies() throws ServiceLocalException {
-    return (StringList) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.Companies);
-
   }
 
   /**
@@ -625,7 +619,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public ContactSource getContactSource() throws ServiceLocalException {
-    return (ContactSource) getPropertyBag()
+    return getPropertyBag()
         .getObjectFromPropertyDefinition(ContactSchema.ContactSource);
   }
 
@@ -636,7 +630,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getDepartment() throws ServiceLocalException {
-    return (String) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.Department);
   }
 
@@ -658,7 +652,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getGeneration() throws ServiceLocalException {
-    return (String) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.Generation);
   }
 
@@ -682,8 +676,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public ImAddressDictionary getImAddresses() throws ServiceLocalException {
-    return (ImAddressDictionary) getPropertyBag()
-        .getObjectFromPropertyDefinition(ContactSchema.ImAddresses);
+    return getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.ImAddresses);
   }
 
   /**
@@ -693,7 +686,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getJobTitle() throws ServiceLocalException {
-    return (String) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.JobTitle);
   }
 
@@ -715,7 +708,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getManager() throws ServiceLocalException {
-    return (String) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.Manager);
   }
 
@@ -737,7 +730,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getMileage() throws ServiceLocalException {
-    return (String) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.Mileage);
   }
 
@@ -759,7 +752,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getOfficeLocation() throws ServiceLocalException {
-    return (String) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.OfficeLocation);
   }
 
@@ -784,9 +777,8 @@ public class Contact extends Item {
    */
   public PhysicalAddressIndex getPostalAddressIndex()
       throws ServiceLocalException {
-    return (PhysicalAddressIndex) getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            ContactSchema.PostalAddressIndex);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ContactSchema.PostalAddressIndex);
   }
 
   /**
@@ -808,7 +800,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getProfession() throws ServiceLocalException {
-    return (String) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.Profession);
   }
 
@@ -830,7 +822,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getSpouseName() throws ServiceLocalException {
-    return (String) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.SpouseName);
   }
 
@@ -852,7 +844,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getSurname() throws ServiceLocalException {
-    return (String) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.Surname);
   }
 
@@ -874,7 +866,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Date getWeddingAnniversary() throws ServiceLocalException {
-    return (Date) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.WeddingAnniversary);
   }
 
@@ -897,7 +889,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getHasPicture() throws ServiceLocalException {
-    return (Boolean) getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ContactSchema.HasPicture);
   }
 
@@ -905,14 +897,14 @@ public class Contact extends Item {
    * Gets the funn phonetic name from the directory
    */
   public String getPhoneticFullName() throws Exception {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.PhoneticFullName);
+    return getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.PhoneticFullName);
   }
 
   /**
    * Gets the funn phonetic name from the directory
    */
   public String getPhoneticFirstName() throws Exception {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.PhoneticFirstName);
+    return getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.PhoneticFirstName);
   }
 
   /**
@@ -921,7 +913,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException
    */
   public String getPhoneticLastName() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.PhoneticLastName);
+    return getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.PhoneticLastName);
   }
 
   /**
@@ -930,7 +922,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException
    */
   public String getAlias() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.Alias);
+    return getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.Alias);
   }
 
   /**
@@ -939,7 +931,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException
    */
   public String getNotes() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.Notes);
+    return getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.Notes);
   }
 
   /**
@@ -948,7 +940,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException
    */
   public byte[] getDirectoryPhoto() throws ServiceLocalException {
-    return (byte[]) this.getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.Photo);
+    return getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.Photo);
   }
 
   /**
@@ -957,12 +949,9 @@ public class Contact extends Item {
    * @throws ServiceLocalException
    */
   public byte[][] getUserSMIMECertificate() throws ServiceLocalException {
-
-    {
-      ByteArrayArray array = (ByteArrayArray) this.getPropertyBag()
-          .getObjectFromPropertyDefinition(ContactSchema.UserSMIMECertificate);
-      return array.getContent();
-    }
+    ByteArrayArray array = this.getPropertyBag()
+        .getObjectFromPropertyDefinition(ContactSchema.UserSMIMECertificate);
+    return array.getContent();
   }
 
   /**
@@ -971,12 +960,9 @@ public class Contact extends Item {
    * @throws ServiceLocalException
    */
   public byte[][] getMSExchangeCertificate() throws ServiceLocalException {
-
-    {
-      ByteArrayArray array = (ByteArrayArray) this.getPropertyBag()
+      ByteArrayArray array = getPropertyBag()
           .getObjectFromPropertyDefinition(ContactSchema.MSExchangeCertificate);
       return array.getContent();
-    }
   }
 
   /**
@@ -985,7 +971,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException
    */
   public String getDirectoryId() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.DirectoryId);
+    return getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.DirectoryId);
   }
 
   /**
@@ -994,7 +980,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException
    */
   public EmailAddress getManagerMailbox() throws ServiceLocalException {
-    return (EmailAddress) this.getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.ManagerMailbox);
+    return getPropertyBag().getObjectFromPropertyDefinition(ContactSchema.ManagerMailbox);
   }
 
   /**
@@ -1003,7 +989,7 @@ public class Contact extends Item {
    * @throws ServiceLocalException
    */
   public EmailAddressCollection getDirectReports() throws ServiceLocalException {
-    return (EmailAddressCollection) this.getPropertyBag()
+    return getPropertyBag()
         .getObjectFromPropertyDefinition(ContactSchema.DirectReports);
   }
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/Conversation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/Conversation.java
@@ -444,9 +444,8 @@ public class Conversation extends ServiceObject {
    * @throws ServiceLocalException
    */
   public ConversationId getId() throws ServiceLocalException {
-    return (ConversationId) this.getPropertyBag().
-        getObjectFromPropertyDefinition(this.getIdPropertyDefinition());
-
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        getIdPropertyDefinition());
   }
 
   /**
@@ -481,8 +480,8 @@ public class Conversation extends ServiceObject {
    * @throws Exception
    */
   public StringList getUniqueRecipients() throws Exception {
-    return (StringList) this.getPropertyBag().
-        getObjectFromPropertyDefinition(ConversationSchema.UniqueRecipients);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ConversationSchema.UniqueRecipients);
   }
 
   /**
@@ -493,10 +492,8 @@ public class Conversation extends ServiceObject {
    * @throws Exception
    */
   public StringList getGlobalUniqueRecipients() throws Exception {
-    return (StringList) this.getPropertyBag().
-        getObjectFromPropertyDefinition(ConversationSchema.
-            GlobalUniqueRecipients);
-
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ConversationSchema.GlobalUniqueRecipients);
   }
 
   /**
@@ -559,9 +556,8 @@ public class Conversation extends ServiceObject {
    * @throws Exception
    */
   public StringList getUniqueSenders() throws Exception {
-    return (StringList) this.getPropertyBag().
-        getObjectFromPropertyDefinition(ConversationSchema.UniqueSenders);
-
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ConversationSchema.UniqueSenders);
   }
 
   /**
@@ -572,8 +568,8 @@ public class Conversation extends ServiceObject {
    * @throws Exception
    */
   public StringList getGlobalUniqueSenders() throws Exception {
-    return (StringList) this.getPropertyBag().
-        getObjectFromPropertyDefinition(ConversationSchema.GlobalUniqueSenders);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ConversationSchema.GlobalUniqueSenders);
   }
 
   /**
@@ -584,9 +580,8 @@ public class Conversation extends ServiceObject {
    * @throws Exception
    */
   public Date getLastDeliveryTime() throws Exception {
-    return (Date) this.getPropertyBag().
-        getObjectFromPropertyDefinition(ConversationSchema.LastDeliveryTime);
-
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ConversationSchema.LastDeliveryTime);
   }
 
   /**
@@ -597,11 +592,8 @@ public class Conversation extends ServiceObject {
    * @throws Exception
    */
   public Date getGlobalLastDeliveryTime() throws Exception {
-
-    return (Date) this.getPropertyBag().
-        getObjectFromPropertyDefinition(ConversationSchema.
-            GlobalLastDeliveryTime);
-
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ConversationSchema.GlobalLastDeliveryTime);
   }
 
   /**
@@ -710,9 +702,7 @@ public class Conversation extends ServiceObject {
    * @throws ServiceLocalException
    */
   public boolean getHasAttachments() throws ServiceLocalException {
-    return ((Boolean) this.getPropertyBag().
-        getObjectFromPropertyDefinition(
-            ConversationSchema.HasAttachments)).booleanValue();
+    return getPropertyBag().<Boolean>getObjectFromPropertyDefinition(ConversationSchema.HasAttachments);
   }
 
   /**
@@ -724,10 +714,8 @@ public class Conversation extends ServiceObject {
    * @throws ServiceLocalException
    */
   public boolean getGlobalHasAttachments() throws ServiceLocalException {
-    return ((Boolean) this.getPropertyBag().
-        getObjectFromPropertyDefinition(
-            ConversationSchema.GlobalHasAttachments)).booleanValue();
-
+    return getPropertyBag().<Boolean>getObjectFromPropertyDefinition(
+        ConversationSchema.GlobalHasAttachments);
   }
 
   /**
@@ -738,9 +726,8 @@ public class Conversation extends ServiceObject {
    * @throws ServiceLocalException
    */
   public int getMessageCount() throws ServiceLocalException {
-    return ((Integer) this.getPropertyBag().
-        getObjectFromPropertyDefinition(
-            ConversationSchema.MessageCount)).intValue();
+    return getPropertyBag().<Integer>getObjectFromPropertyDefinition(
+        ConversationSchema.MessageCount);
   }
 
   /**
@@ -751,11 +738,8 @@ public class Conversation extends ServiceObject {
    * @throws ServiceLocalException
    */
   public int getGlobalMessageCount() throws ServiceLocalException {
-
-    return ((Integer) this.getPropertyBag().
-        getObjectFromPropertyDefinition(
-            ConversationSchema.GlobalMessageCount)).intValue();
-
+    return getPropertyBag().<Integer>getObjectFromPropertyDefinition(
+        ConversationSchema.GlobalMessageCount);
   }
 
   /**
@@ -814,9 +798,8 @@ public class Conversation extends ServiceObject {
    * @throws ServiceLocalException
    */
   public int getSize() throws ServiceLocalException {
-    return ((Integer) this.getPropertyBag().
-        getObjectFromPropertyDefinition(
-            ConversationSchema.Size)).intValue();
+    return getPropertyBag().<Integer>getObjectFromPropertyDefinition(
+        ConversationSchema.Size);
   }
 
   /**
@@ -828,9 +811,8 @@ public class Conversation extends ServiceObject {
    * @throws ServiceLocalException
    */
   public int getGlobalSize() throws ServiceLocalException {
-    return ((Integer) this.getPropertyBag().
-        getObjectFromPropertyDefinition(
-            ConversationSchema.GlobalSize)).intValue();
+    return getPropertyBag().<Integer>getObjectFromPropertyDefinition(
+        ConversationSchema.GlobalSize);
   }
 
   /**
@@ -841,9 +823,8 @@ public class Conversation extends ServiceObject {
    * @throws Exception
    */
   public StringList getItemClasses() throws Exception {
-    return (StringList) this.getPropertyBag().
-        getObjectFromPropertyDefinition(
-            ConversationSchema.ItemClasses);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ConversationSchema.ItemClasses);
   }
 
   /**
@@ -854,10 +835,8 @@ public class Conversation extends ServiceObject {
    * @throws Exception
    */
   public StringList getGlobalItemClasses() throws Exception {
-    return (StringList) this.getPropertyBag().
-        getObjectFromPropertyDefinition(
-            ConversationSchema.GlobalItemClasses);
-
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ConversationSchema.GlobalItemClasses);
   }
 
   /**
@@ -868,9 +847,8 @@ public class Conversation extends ServiceObject {
    * @throws Exception
    */
   public Importance getImportance() throws Exception {
-    return (Importance) this.getPropertyBag().
-        getObjectFromPropertyDefinition(
-            ConversationSchema.Importance);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ConversationSchema.Importance);
   }
 
   /**
@@ -882,9 +860,8 @@ public class Conversation extends ServiceObject {
    * @throws Exception
    */
   public Importance getGlobalImportance() throws Exception {
-    return (Importance) this.getPropertyBag().
-        getObjectFromPropertyDefinition(
-            ConversationSchema.GlobalImportance);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ConversationSchema.GlobalImportance);
   }
 
   /**
@@ -895,9 +872,8 @@ public class Conversation extends ServiceObject {
    * @throws Exception
    */
   public ItemIdCollection getItemIds() throws Exception {
-    return (ItemIdCollection) this.getPropertyBag().
-        getObjectFromPropertyDefinition(
-            ConversationSchema.ItemIds);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ConversationSchema.ItemIds);
   }
 
   /**
@@ -908,9 +884,8 @@ public class Conversation extends ServiceObject {
    * @throws Exception
    */
   public ItemIdCollection getGlobalItemIds() throws Exception {
-    return (ItemIdCollection) this.getPropertyBag().
-        getObjectFromPropertyDefinition(
-            ConversationSchema.GlobalItemIds);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ConversationSchema.GlobalItemIds);
   }
 
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/EmailMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/EmailMessage.java
@@ -324,9 +324,8 @@ public class EmailMessage extends Item {
    */
   public EmailAddressCollection getToRecipients()
       throws ServiceLocalException {
-    return (EmailAddressCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            EmailMessageSchema.ToRecipients);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        EmailMessageSchema.ToRecipients);
   }
 
   /**
@@ -337,9 +336,8 @@ public class EmailMessage extends Item {
    */
   public EmailAddressCollection getBccRecipients()
       throws ServiceLocalException {
-    return (EmailAddressCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            EmailMessageSchema.BccRecipients);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        EmailMessageSchema.BccRecipients);
   }
 
   /**
@@ -350,9 +348,8 @@ public class EmailMessage extends Item {
    */
   public EmailAddressCollection getCcRecipients()
       throws ServiceLocalException {
-    return (EmailAddressCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            EmailMessageSchema.CcRecipients);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        EmailMessageSchema.CcRecipients);
   }
 
   /**
@@ -362,7 +359,7 @@ public class EmailMessage extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getConversationTopic() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.ConversationTopic);
   }
 
@@ -373,7 +370,7 @@ public class EmailMessage extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public byte[] getConversationIndex() throws ServiceLocalException {
-    return (byte[]) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.ConversationIndex);
   }
 
@@ -384,8 +381,8 @@ public class EmailMessage extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public EmailAddress getFrom() throws ServiceLocalException {
-    return (EmailAddress) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(EmailMessageSchema.From);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        EmailMessageSchema.From);
   }
 
   /**
@@ -437,7 +434,7 @@ public class EmailMessage extends Item {
    */
   public Boolean getIsDeliveryReceiptRequested()
       throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.IsDeliveryReceiptRequested);
   }
 
@@ -459,7 +456,7 @@ public class EmailMessage extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsRead() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.IsRead);
   }
 
@@ -482,7 +479,7 @@ public class EmailMessage extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsReadReceiptRequested() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.IsReadReceiptRequested);
   }
 
@@ -505,7 +502,7 @@ public class EmailMessage extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsResponseRequested() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.IsResponseRequested);
   }
 
@@ -527,7 +524,7 @@ public class EmailMessage extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getInternetMessageId() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.InternetMessageId);
   }
 
@@ -538,7 +535,7 @@ public class EmailMessage extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getReferences() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.References);
   }
 
@@ -560,7 +557,7 @@ public class EmailMessage extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public EmailAddressCollection getReplyTo() throws ServiceLocalException {
-    return (EmailAddressCollection) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.ReplyTo);
   }
 
@@ -571,8 +568,8 @@ public class EmailMessage extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public EmailAddress getSender() throws ServiceLocalException {
-    return (EmailAddress) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(EmailMessageSchema.Sender);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        EmailMessageSchema.Sender);
   }
 
   /**
@@ -593,8 +590,8 @@ public class EmailMessage extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public EmailAddress getReceivedBy() throws ServiceLocalException {
-    return (EmailAddress) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(EmailMessageSchema.ReceivedBy);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        EmailMessageSchema.ReceivedBy);
   }
 
   /**
@@ -604,8 +601,7 @@ public class EmailMessage extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public EmailAddress getReceivedRepresenting() throws ServiceLocalException {
-    return (EmailAddress) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            EmailMessageSchema.ReceivedRepresenting);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        EmailMessageSchema.ReceivedRepresenting);
   }
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/Item.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/Item.java
@@ -591,8 +591,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public ItemId getId() throws ServiceLocalException {
-    return (ItemId) this.getPropertyBag().getObjectFromPropertyDefinition(
-        this.getIdPropertyDefinition());
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        getIdPropertyDefinition());
   }
 
   /**
@@ -602,8 +602,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public MimeContent getMimeContent() throws ServiceLocalException {
-    return (MimeContent) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.MimeContent);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ItemSchema.MimeContent);
   }
 
   /**
@@ -624,8 +624,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public FolderId getParentFolderId() throws ServiceLocalException {
-    return (FolderId) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.ParentFolderId);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ItemSchema.ParentFolderId);
   }
 
   /**
@@ -635,8 +635,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public Sensitivity getSensitivity() throws ServiceLocalException {
-    return (Sensitivity) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.Sensitivity);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ItemSchema.Sensitivity);
   }
 
   /**
@@ -657,8 +657,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public AttachmentCollection getAttachments() throws ServiceLocalException {
-    return (AttachmentCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.Attachments);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ItemSchema.Attachments);
   }
 
   /**
@@ -668,7 +668,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public Date getDateTimeReceived() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.DateTimeReceived);
   }
 
@@ -679,8 +679,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public int getSize() throws ServiceLocalException {
-    return ((Integer) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.Size)).intValue();
+    return getPropertyBag().<Integer>getObjectFromPropertyDefinition(ItemSchema.Size);
   }
 
   /**
@@ -690,8 +689,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public StringList getCategories() throws ServiceLocalException {
-    return (StringList) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.Categories);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ItemSchema.Categories);
   }
 
   /**
@@ -712,7 +711,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public String getCulture() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.Culture);
   }
 
@@ -734,8 +733,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public Importance getImportance() throws ServiceLocalException {
-    return (Importance) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.Importance);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ItemSchema.Importance);
   }
 
   /**
@@ -756,7 +755,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public String getInReplyTo() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.InReplyTo);
   }
 
@@ -779,9 +778,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public boolean getIsSubmitted() throws ServiceLocalException {
-    return ((Boolean) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.IsSubmitted))
-        .booleanValue();
+    return getPropertyBag().<Boolean>getObjectFromPropertyDefinition(ItemSchema.IsSubmitted);
   }
 
   /**
@@ -792,9 +789,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public boolean getIsAssociated() throws ServiceLocalException {
-    return ((Boolean) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.IsAssociated))
-        .booleanValue();
+    return getPropertyBag().<Boolean>getObjectFromPropertyDefinition(
+        ItemSchema.IsAssociated);
   }
 
   /**
@@ -805,9 +801,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public boolean getIsDraft() throws ServiceLocalException {
-    return ((Boolean) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.IsDraft))
-        .booleanValue();
+    return getPropertyBag().<Boolean>getObjectFromPropertyDefinition(
+        ItemSchema.IsDraft);
   }
 
   /**
@@ -818,9 +813,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public boolean getIsFromMe() throws ServiceLocalException {
-    return ((Boolean) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.IsFromMe))
-        .booleanValue();
+    return getPropertyBag().<Boolean>getObjectFromPropertyDefinition(
+        ItemSchema.IsFromMe);
   }
 
   /**
@@ -830,9 +824,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public boolean getIsResend() throws ServiceLocalException {
-    return ((Boolean) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.IsResend))
-        .booleanValue();
+    return getPropertyBag().<Boolean>getObjectFromPropertyDefinition(
+        ItemSchema.IsResend);
   }
 
   /**
@@ -843,10 +836,8 @@ public class Item extends ServiceObject {
    * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
    */
   public boolean getIsUnmodified() throws ServiceLocalException {
-    return ((Boolean) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.IsUnmodified))
-        .booleanValue();
-
+    return getPropertyBag().<Boolean>getObjectFromPropertyDefinition(
+        ItemSchema.IsUnmodified);
   }
 
   /**
@@ -857,9 +848,8 @@ public class Item extends ServiceObject {
    */
   public InternetMessageHeaderCollection getInternetMessageHeaders()
       throws ServiceLocalException {
-    return (InternetMessageHeaderCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            ItemSchema.InternetMessageHeaders);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ItemSchema.InternetMessageHeaders);
   }
 
   /**
@@ -869,7 +859,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public Date getDateTimeSent() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.DateTimeSent);
   }
 
@@ -880,7 +870,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public Date getDateTimeCreated() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.DateTimeCreated);
   }
 
@@ -893,9 +883,8 @@ public class Item extends ServiceObject {
    */
   public EnumSet<ResponseActions> getAllowedResponseActions()
       throws ServiceLocalException {
-    return (EnumSet<ResponseActions>) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            ItemSchema.AllowedResponseActions);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ItemSchema.AllowedResponseActions);
   }
 
   /**
@@ -905,7 +894,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public Date getReminderDueBy() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.ReminderDueBy);
   }
 
@@ -927,9 +916,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public boolean getIsReminderSet() throws ServiceLocalException {
-    return ((Boolean) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.IsReminderSet))
-        .booleanValue();
+    return getPropertyBag().<Boolean>getObjectFromPropertyDefinition(
+        ItemSchema.IsReminderSet);
   }
 
   /**
@@ -951,9 +939,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public int getReminderMinutesBeforeStart() throws ServiceLocalException {
-    return ((Integer) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            ItemSchema.ReminderMinutesBeforeStart)).intValue();
+    return getPropertyBag().<Integer>getObjectFromPropertyDefinition(
+        ItemSchema.ReminderMinutesBeforeStart);
   }
 
   /**
@@ -974,7 +961,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public String getDisplayCc() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.DisplayCc);
   }
 
@@ -985,7 +972,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public String getDisplayTo() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.DisplayTo);
   }
 
@@ -996,9 +983,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public boolean getHasAttachments() throws ServiceLocalException {
-    return ((Boolean) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.HasAttachments))
-        .booleanValue();
+    return getPropertyBag().<Boolean>getObjectFromPropertyDefinition(
+        ItemSchema.HasAttachments);
   }
 
   /**
@@ -1008,8 +994,7 @@ public class Item extends ServiceObject {
    * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
    */
   public MessageBody getBody() throws ServiceLocalException {
-    return (MessageBody) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.Body);
+    return getPropertyBag().getObjectFromPropertyDefinition(ItemSchema.Body);
   }
 
   /**
@@ -1030,7 +1015,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public String getItemClass() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.ItemClass);
   }
 
@@ -1073,7 +1058,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public String getSubject() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.Subject);
   }
 
@@ -1086,7 +1071,7 @@ public class Item extends ServiceObject {
    */
   public String getWebClientReadFormQueryString()
       throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.WebClientReadFormQueryString);
   }
 
@@ -1099,7 +1084,7 @@ public class Item extends ServiceObject {
    */
   public String getWebClientEditFormQueryString()
       throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.WebClientEditFormQueryString);
   }
 
@@ -1112,9 +1097,8 @@ public class Item extends ServiceObject {
   @Override
   public ExtendedPropertyCollection getExtendedProperties()
       throws ServiceLocalException {
-    return (ExtendedPropertyCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            ServiceObjectSchema.extendedProperties);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ServiceObjectSchema.extendedProperties);
   }
 
   /**
@@ -1126,8 +1110,8 @@ public class Item extends ServiceObject {
    */
   public EnumSet<EffectiveRights> getEffectiveRights()
       throws ServiceLocalException {
-    return (EnumSet<EffectiveRights>) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.EffectiveRights);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ItemSchema.EffectiveRights);
   }
 
   /**
@@ -1137,7 +1121,7 @@ public class Item extends ServiceObject {
    * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
    */
   public String getLastModifiedName() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.LastModifiedName);
   }
 
@@ -1148,7 +1132,7 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public Date getLastModifiedTime() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         ItemSchema.LastModifiedTime);
   }
 
@@ -1159,8 +1143,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public ConversationId getConversationId() throws ServiceLocalException {
-    return (ConversationId) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.ConversationId);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ItemSchema.ConversationId);
   }
 
   /**
@@ -1171,8 +1155,8 @@ public class Item extends ServiceObject {
    * @throws ServiceLocalException the service local exception
    */
   public UniqueBody getUniqueBody() throws ServiceLocalException {
-    return (UniqueBody) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(ItemSchema.UniqueBody);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        ItemSchema.UniqueBody);
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/MeetingMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/MeetingMessage.java
@@ -127,9 +127,8 @@ public class MeetingMessage extends EmailMessage {
    */
   public ItemId getAssociatedAppointmentId()
       throws ServiceLocalException {
-    return (ItemId) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            MeetingMessageSchema.AssociatedAppointmentId);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        MeetingMessageSchema.AssociatedAppointmentId);
   }
 
   /**
@@ -140,9 +139,8 @@ public class MeetingMessage extends EmailMessage {
    */
   public Boolean getHasBeenProcessed()
       throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            MeetingMessageSchema.HasBeenProcessed);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        MeetingMessageSchema.HasBeenProcessed);
   }
 
   /**
@@ -153,9 +151,8 @@ public class MeetingMessage extends EmailMessage {
    */
   public MeetingResponseType getResponseType()
       throws ServiceLocalException {
-    return (MeetingResponseType) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            MeetingMessageSchema.ResponseType);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        MeetingMessageSchema.ResponseType);
   }
 
   /**
@@ -165,7 +162,7 @@ public class MeetingMessage extends EmailMessage {
    * @throws ServiceLocalException the service local exception
    */
   public String getICalUid() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         MeetingMessageSchema.ICalUid);
   }
 
@@ -176,7 +173,7 @@ public class MeetingMessage extends EmailMessage {
    * @throws ServiceLocalException the service local exception
    */
   public Date getICalRecurrenceId() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         MeetingMessageSchema.ICalRecurrenceId);
   }
 
@@ -187,7 +184,7 @@ public class MeetingMessage extends EmailMessage {
    * @throws ServiceLocalException the service local exception
    */
   public Date getICalDateTimeStamp() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         MeetingMessageSchema.ICalDateTimeStamp);
   }
 
@@ -198,7 +195,7 @@ public class MeetingMessage extends EmailMessage {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsDelegated() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         MeetingMessageSchema.IsDelegated);
   }
 
@@ -209,7 +206,7 @@ public class MeetingMessage extends EmailMessage {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsOutOfDate() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         MeetingMessageSchema.IsOutOfDate);
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/MeetingRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/MeetingRequest.java
@@ -245,9 +245,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    */
   public MeetingRequestType getMeetingRequestType()
       throws ServiceLocalException {
-    return (MeetingRequestType) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            MeetingRequestSchema.MeetingRequestType);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        MeetingRequestSchema.MeetingRequestType);
   }
 
   /**
@@ -259,10 +258,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    */
   public LegacyFreeBusyStatus getIntendedFreeBusyStatus()
       throws ServiceLocalException {
-    return (LegacyFreeBusyStatus) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            MeetingRequestSchema.IntendedFreeBusyStatus);
-
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        MeetingRequestSchema.IntendedFreeBusyStatus);
   }
 
   /**
@@ -272,7 +269,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public Date getStart() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.Start);
   }
 
@@ -283,7 +280,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public Date getEnd() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.End);
   }
 
@@ -294,7 +291,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public Date getOriginalStart() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.OriginalStart);
   }
 
@@ -305,7 +302,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public boolean getIsAllDayEvent() throws ServiceLocalException {
-    return this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.IsAllDayEvent) != null;
   }
 
@@ -318,9 +315,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    */
   public LegacyFreeBusyStatus legacyFreeBusyStatus()
       throws ServiceLocalException {
-    return (LegacyFreeBusyStatus) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.LegacyFreeBusyStatus);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.LegacyFreeBusyStatus);
   }
 
   /**
@@ -330,7 +326,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public String getLocation() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.Location);
   }
 
@@ -344,7 +340,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public String getWhen() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.When);
   }
 
@@ -355,7 +351,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public boolean getIsMeeting() throws ServiceLocalException {
-    return this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.IsMeeting) != null;
   }
 
@@ -366,7 +362,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public boolean getIsCancelled() throws ServiceLocalException {
-    return this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.IsCancelled) != null;
   }
 
@@ -377,7 +373,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public boolean getIsRecurring() throws ServiceLocalException {
-    return this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.IsRecurring) != null;
   }
 
@@ -389,7 +385,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public boolean getMeetingRequestWasSent() throws ServiceLocalException {
-    return this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.MeetingRequestWasSent) != null;
   }
 
@@ -400,9 +396,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public AppointmentType getAppointmentType() throws ServiceLocalException {
-    return (AppointmentType) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.AppointmentType);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.AppointmentType);
   }
 
   /**
@@ -414,9 +409,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    */
   public MeetingResponseType getMyResponseType()
       throws ServiceLocalException {
-    return (MeetingResponseType) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.MyResponseType);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.MyResponseType);
   }
 
   /**
@@ -426,8 +420,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public EmailAddress getOrganizer() throws ServiceLocalException {
-    return (EmailAddress) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(AppointmentSchema.Organizer);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.Organizer);
   }
 
   /**
@@ -438,9 +432,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    */
   public AttendeeCollection getRequiredAttendees()
       throws ServiceLocalException {
-    return (AttendeeCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.RequiredAttendees);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.RequiredAttendees);
   }
 
   /**
@@ -451,9 +444,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    */
   public AttendeeCollection getOptionalAttendees()
       throws ServiceLocalException {
-    return (AttendeeCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.OptionalAttendees);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.OptionalAttendees);
   }
 
   /**
@@ -463,8 +455,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public AttendeeCollection getResources() throws ServiceLocalException {
-    return (AttendeeCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(AppointmentSchema.Resources);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.Resources);
   }
 
   /**
@@ -506,9 +498,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    */
   public ItemCollection<Appointment> getConflictingMeetings()
       throws ServiceLocalException {
-    return (ItemCollection<Appointment>) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.ConflictingMeetings);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.ConflictingMeetings);
   }
 
   /**
@@ -520,9 +511,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    */
   public ItemCollection<Appointment> getAdjacentMeetings()
       throws ServiceLocalException {
-    return (ItemCollection<Appointment>) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.AdjacentMeetings);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.AdjacentMeetings);
   }
 
   /**
@@ -532,8 +522,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public TimeSpan getDuration() throws ServiceLocalException {
-    return (TimeSpan) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(AppointmentSchema.Duration);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.Duration);
   }
 
   /**
@@ -543,7 +533,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public String getTimeZone() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.TimeZone);
   }
 
@@ -554,7 +544,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public Date getAppointmentReplyTime() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.AppointmentReplyTime);
   }
 
@@ -595,8 +585,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public Recurrence getRecurrence() throws ServiceLocalException {
-    return (Recurrence) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(AppointmentSchema.Recurrence);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.Recurrence);
   }
 
   /**
@@ -606,9 +596,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public OccurrenceInfo getFirstOccurrence() throws ServiceLocalException {
-    return (OccurrenceInfo) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.FirstOccurrence);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.FirstOccurrence);
   }
 
   /**
@@ -618,9 +607,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public OccurrenceInfo getLastOccurrence() throws ServiceLocalException {
-    return (OccurrenceInfo) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.FirstOccurrence);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.FirstOccurrence);
   }
 
   /**
@@ -631,9 +619,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    */
   public OccurrenceInfoCollection getModifiedOccurrences()
       throws ServiceLocalException {
-    return (OccurrenceInfoCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.ModifiedOccurrences);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.ModifiedOccurrences);
   }
 
   /**
@@ -644,9 +631,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    */
   public DeletedOccurrenceInfoCollection getDeletedOccurrences()
       throws ServiceLocalException {
-    return (DeletedOccurrenceInfoCollection) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.DeletedOccurrences);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.DeletedOccurrences);
   }
 
   /**
@@ -656,9 +642,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public TimeZoneDefinition getStartTimeZone() throws ServiceLocalException {
-    return (TimeZoneDefinition) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            AppointmentSchema.StartTimeZone);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.StartTimeZone);
   }
 
   /**
@@ -668,8 +653,8 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public TimeZoneDefinition getEndTimeZone() throws ServiceLocalException {
-    return (TimeZoneDefinition) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(AppointmentSchema.EndTimeZone);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        AppointmentSchema.EndTimeZone);
   }
 
   /**
@@ -694,7 +679,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public boolean getAllowNewTimeProposal() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().<Boolean>getObjectFromPropertyDefinition(
         AppointmentSchema.AllowNewTimeProposal);
   }
 
@@ -705,7 +690,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public boolean getIsOnlineMeeting() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().<Boolean>getObjectFromPropertyDefinition(
         AppointmentSchema.IsOnlineMeeting);
   }
 
@@ -718,7 +703,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public String getMeetingWorkspaceUrl() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.MeetingWorkspaceUrl);
   }
 
@@ -729,7 +714,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
    * @throws ServiceLocalException the service local exception
    */
   public String getNetShowUrl() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         AppointmentSchema.NetShowUrl);
   }
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/PostItem.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/PostItem.java
@@ -231,7 +231,7 @@ public final class PostItem extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public byte[] getConversationIndex() throws ServiceLocalException {
-    return (byte[]) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.ConversationIndex);
   }
 
@@ -242,7 +242,7 @@ public final class PostItem extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getConversationTopic() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.ConversationTopic);
   }
 
@@ -253,8 +253,8 @@ public final class PostItem extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public EmailAddress getFrom() throws ServiceLocalException {
-    return (EmailAddress) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(EmailMessageSchema.From);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        EmailMessageSchema.From);
   }
 
   /**
@@ -275,7 +275,7 @@ public final class PostItem extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getInternetMessageId() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.InternetMessageId);
   }
 
@@ -286,7 +286,7 @@ public final class PostItem extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsRead() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.IsRead);
   }
 
@@ -308,7 +308,7 @@ public final class PostItem extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Date getPostedTime() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         PostItemSchema.PostedTime);
   }
 
@@ -319,7 +319,7 @@ public final class PostItem extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getReferences() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         EmailMessageSchema.References);
   }
 
@@ -341,8 +341,8 @@ public final class PostItem extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public EmailAddress getSender() throws ServiceLocalException {
-    return (EmailAddress) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(EmailMessageSchema.Sender);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        EmailMessageSchema.Sender);
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/Task.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/Task.java
@@ -183,7 +183,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Integer getActualWork() throws ServiceLocalException {
-    return (Integer) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.ActualWork);
   }
 
@@ -205,7 +205,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Date getAssignedTime() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.AssignedTime);
   }
 
@@ -216,7 +216,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getBillingInformation() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.BillingInformation);
   }
 
@@ -238,7 +238,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Integer getChangeCount() throws ServiceLocalException {
-    return (Integer) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.ChangeCount);
   }
 
@@ -249,8 +249,8 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public StringList getCompanies() throws ServiceLocalException {
-    return (StringList) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(TaskSchema.Companies);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        TaskSchema.Companies);
   }
 
   /**
@@ -271,7 +271,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Date getCompleteDate() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.CompleteDate);
   }
 
@@ -293,8 +293,8 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public StringList getContacts() throws ServiceLocalException {
-    return (StringList) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(TaskSchema.Contacts);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        TaskSchema.Contacts);
   }
 
   /**
@@ -316,8 +316,8 @@ public class Task extends Item {
    */
   public TaskDelegationState getDelegationState()
       throws ServiceLocalException {
-    return (TaskDelegationState) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(TaskSchema.DelegationState);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        TaskSchema.DelegationState);
   }
 
   /**
@@ -327,7 +327,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getDelegator() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.Delegator);
   }
 
@@ -338,7 +338,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Date getDueDate() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.DueDate);
   }
 
@@ -360,8 +360,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public TaskMode getMode() throws ServiceLocalException {
-    return (TaskMode) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(TaskSchema.Mode);
+    return getPropertyBag().getObjectFromPropertyDefinition(TaskSchema.Mode);
   }
 
   /**
@@ -371,7 +370,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsComplete() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.IsComplete);
   }
 
@@ -382,7 +381,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsRecurring() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.IsRecurring);
   }
 
@@ -393,7 +392,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Boolean getIsTeamTask() throws ServiceLocalException {
-    return (Boolean) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.IsTeamTask);
   }
 
@@ -404,7 +403,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getMileage() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.Mileage);
   }
 
@@ -426,7 +425,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getOwner() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.Owner);
   }
 
@@ -439,7 +438,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Double getPercentComplete() throws ServiceLocalException {
-    return (Double) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.PercentComplete);
   }
 
@@ -484,8 +483,8 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Recurrence getRecurrence() throws ServiceLocalException {
-    return (Recurrence) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(TaskSchema.Recurrence);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        TaskSchema.Recurrence);
   }
 
   /**
@@ -506,7 +505,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Date getStartDate() throws ServiceLocalException {
-    return (Date) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.StartDate);
   }
 
@@ -528,8 +527,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public TaskStatus getStatus() throws ServiceLocalException {
-    return (TaskStatus) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(TaskSchema.Status);
+    return getPropertyBag().getObjectFromPropertyDefinition(TaskSchema.Status);
   }
 
   /**
@@ -552,7 +550,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public String getStatusDescription() throws ServiceLocalException {
-    return (String) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.StatusDescription);
   }
 
@@ -563,7 +561,7 @@ public class Task extends Item {
    * @throws ServiceLocalException the service local exception
    */
   public Integer getTotalWork() throws ServiceLocalException {
-    return (Integer) this.getPropertyBag().getObjectFromPropertyDefinition(
+    return getPropertyBag().getObjectFromPropertyDefinition(
         TaskSchema.TotalWork);
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/response/CancelMeetingMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/response/CancelMeetingMessage.java
@@ -77,9 +77,8 @@ public final class CancelMeetingMessage extends
    * @throws ServiceLocalException the service local exception
    */
   public MessageBody getBody() throws ServiceLocalException {
-    return (MessageBody) this.getPropertyBag()
-        .getObjectFromPropertyDefinition(
-            CancelMeetingMessageSchema.Body);
+    return getPropertyBag().getObjectFromPropertyDefinition(
+        CancelMeetingMessageSchema.Body);
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/time/TimeZoneDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/time/TimeZoneDefinition.java
@@ -23,7 +23,6 @@
 
 package microsoft.exchange.webservices.data.property.complex.time;
 
-import microsoft.exchange.webservices.data.property.complex.ComplexProperty;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlWriter;
 import microsoft.exchange.webservices.data.core.XmlAttributeNames;
@@ -33,8 +32,15 @@ import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.InvalidOrUnsupportedTimeZoneDefinitionException;
 import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
+import microsoft.exchange.webservices.data.property.complex.ComplexProperty;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a time zone as defined by the EWS schema.
@@ -274,7 +280,7 @@ public class TimeZoneDefinition extends ComplexProperty implements Comparator<Ti
 
         Iterator<TimeZonePeriod> it = this.periods.values().iterator();
         while (it.hasNext()) {
-          ((TimeZonePeriod) it.next()).writeToXml(writer);
+          it.next().writeToXml(writer);
         }
 
         writer.writeEndElement(); // Periods

--- a/src/main/java/microsoft/exchange/webservices/data/property/definition/ComplexPropertyDefinitionBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/definition/ComplexPropertyDefinitionBase.java
@@ -174,8 +174,8 @@ public abstract class ComplexPropertyDefinitionBase extends PropertyDefinition {
   @Override public void writePropertyValueToXml(EwsServiceXmlWriter writer, PropertyBag propertyBag,
       boolean isUpdateOperation)
       throws Exception {
-    ComplexProperty complexProperty = (ComplexProperty) propertyBag
-        .getObjectFromPropertyDefinition(this);
+    ComplexProperty complexProperty =
+      propertyBag.getObjectFromPropertyDefinition(this);
     if (complexProperty != null) {
       complexProperty.writeToXml(writer, this.getXmlElement());
     }

--- a/src/main/java/microsoft/exchange/webservices/data/property/definition/MeetingTimeZonePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/definition/MeetingTimeZonePropertyDefinition.java
@@ -80,8 +80,7 @@ public class MeetingTimeZonePropertyDefinition extends PropertyDefinition {
   public void writePropertyValueToXml(EwsServiceXmlWriter writer, PropertyBag propertyBag,
       boolean isUpdateOperation)
       throws Exception {
-    MeetingTimeZone value = (MeetingTimeZone) propertyBag
-        .getObjectFromPropertyDefinition(this);
+    MeetingTimeZone value = propertyBag.getObjectFromPropertyDefinition(this);
 
     if (value != null) {
       value.writeToXml(writer, this.getXmlElement());

--- a/src/main/java/microsoft/exchange/webservices/data/property/definition/RecurrencePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/definition/RecurrencePropertyDefinition.java
@@ -165,8 +165,7 @@ public class RecurrencePropertyDefinition extends PropertyDefinition {
   public void writePropertyValueToXml(EwsServiceXmlWriter writer, PropertyBag propertyBag,
       boolean isUpdateOperation)
       throws Exception {
-    Recurrence value = (Recurrence) propertyBag
-        .getObjectFromPropertyDefinition(this);
+    Recurrence value = propertyBag.getObjectFromPropertyDefinition(this);
 
     if (value != null) {
       value.writeToXml(writer, XmlElementNames.Recurrence);

--- a/src/main/java/microsoft/exchange/webservices/data/property/definition/TimeZonePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/definition/TimeZonePropertyDefinition.java
@@ -79,10 +79,8 @@ public class TimeZonePropertyDefinition extends PropertyDefinition {
    * @throws Exception                                                 the exception
    */
   public void writePropertyValueToXml(EwsServiceXmlWriter writer, PropertyBag propertyBag,
-      boolean isUpdateOperation)
-      throws ServiceLocalException, XMLStreamException, ServiceXmlSerializationException, Exception {
-    TimeZoneDefinition timeZoneDefinition = (TimeZoneDefinition) propertyBag
-        .getObjectFromPropertyDefinition(this);
+      boolean isUpdateOperation) throws Exception {
+    TimeZoneDefinition timeZoneDefinition = propertyBag.getObjectFromPropertyDefinition(this);
 
     if (timeZoneDefinition != null) {
       // We emit time zone property only if we have not emitted the time

--- a/src/main/java/microsoft/exchange/webservices/data/search/FindItemsResults.java
+++ b/src/main/java/microsoft/exchange/webservices/data/search/FindItemsResults.java
@@ -139,7 +139,7 @@ public final class FindItemsResults<TItem extends Item> implements
    */
   @Override
   public Iterator<TItem> iterator() {
-    return (Iterator<TItem>) this.items.iterator();
+    return items.iterator();
   }
 
 }

--- a/src/test/java/microsoft/exchange/webservices/data/core/PropertyBagTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/core/PropertyBagTest.java
@@ -27,7 +27,9 @@ import microsoft.exchange.webservices.data.core.service.ServiceObject;
 import microsoft.exchange.webservices.data.core.service.item.Item;
 import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.exception.ArgumentException;
+import microsoft.exchange.webservices.data.exception.ServiceObjectPropertyException;
 import microsoft.exchange.webservices.data.misc.OutParam;
+import microsoft.exchange.webservices.data.property.definition.IntPropertyDefinition;
 import microsoft.exchange.webservices.data.property.definition.RecurrencePropertyDefinition;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,9 +46,21 @@ public class PropertyBagTest {
    */
   @Test(expected=ArgumentException.class)
   public void tryGetPropertyType() throws Exception{
-    ExchangeService es = new ExchangeService();
-    ServiceObject owner = new Item(es);
-    PropertyBag pb = new PropertyBag(owner);
+    PropertyBag pb = createPropertyBag();
     pb.tryGetPropertyType(String.class, new RecurrencePropertyDefinition("test", "none", null, ExchangeVersion.Exchange2010_SP2), new OutParam<String>());
   }
+
+  @Test(expected = ServiceObjectPropertyException.class)
+  public void testGetObjectFromPropertyDefinition() throws Exception {
+    PropertyBag pb = createPropertyBag();
+    pb.getObjectFromPropertyDefinition(new IntPropertyDefinition("", "none", ExchangeVersion.Exchange2007_SP1));
+  }
+
+
+  private PropertyBag createPropertyBag() throws Exception {
+    ExchangeService es = new ExchangeService();
+    ServiceObject owner = new Item(es);
+    return new PropertyBag(owner);
+  }
+
 }

--- a/src/test/java/microsoft/exchange/webservices/data/property/complex/UserConfigurationDictionaryTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/property/complex/UserConfigurationDictionaryTest.java
@@ -60,7 +60,7 @@ public class UserConfigurationDictionaryTest extends BaseTest {
    */
   @Test(expected = ServiceLocalException.class)
   public void testAddUnsupportedElementsToDictionary() throws Exception {
-    this.userConfigurationDictionary.addElement("someDouble", (Double) 1.0);
+    this.userConfigurationDictionary.addElement("someDouble", 1.0);
   }
 
   /**


### PR DESCRIPTION
Class PropertyBag could be simplified:
```java
<T> T getObjectFromPropertyDefinition
```
instead of
```java
Object getObjectFromPropertyDefinition
```

It prevents a lot of unnecessary type casting / unnecessary code.