### PR TITLE
Remove problematic assertion fixes #105

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
@@ -830,10 +830,6 @@ public abstract class ExchangeServiceBase implements Closeable {
    * @param headers The response headers
    */
   private void saveHttpResponseHeaders(Map<String, String> headers) {
-    EwsUtilities.EwsAssert(this.httpResponseHeaders.size() == 0,
-        "ExchangeServiceBase.SaveHttpResponseHeaders",
-        "expect no headers in the dictionary yet.");
-
     this.httpResponseHeaders.clear();
 
     for (String key : headers.keySet()) {


### PR DESCRIPTION
Seemingly pointless annotation makes writing CI tests or enabling assertions very difficult. Have ran this in production (before this was on github) without any affects.

Example stack trace for posterity
```
java.lang.AssertionError: [ExchangeServiceBase.SaveHttpResponseHeaders] expect no headers in the dictionary yet.
	at microsoft.exchange.webservices.data.EwsUtilities.EwsAssert(EwsUtilities.java:350)
	at microsoft.exchange.webservices.data.ExchangeServiceBase.saveHttpResponseHeaders(ExchangeServiceBase.java:822)
	at microsoft.exchange.webservices.data.ExchangeServiceBase.processHttpResponseHeaders(ExchangeServiceBase.java:813)
	at microsoft.exchange.webservices.data.ExchangeServiceBase.internalProcessHttpErrorResponse(ExchangeServiceBase.java:319)
	at microsoft.exchange.webservices.data.ExchangeService.processHttpErrorResponse(ExchangeService.java:3696)
	at microsoft.exchange.webservices.data.ServiceRequestBase.processWebException(ServiceRequestBase.java:596)
	at microsoft.exchange.webservices.data.ServiceRequestBase.validateAndEmitRequest(ServiceRequestBase.java:696)
	at microsoft.exchange.webservices.data.SimpleServiceRequestBase.internalExecute(SimpleServiceRequestBase.java:58)
	at microsoft.exchange.webservices.data.MultiResponseServiceRequest.execute(MultiResponseServiceRequest.java:147)
	at microsoft.exchange.webservices.data.ExchangeService.findItems(ExchangeService.java:824)
	at microsoft.exchange.webservices.data.ExchangeService.findAppointments(ExchangeService.java:1106)
```