### PR TITLE
Optimize creation of collections (using Arrays.asList)

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
@@ -185,7 +185,16 @@ import org.w3c.dom.Node;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
 
 /**
  * Represents a binding to the Exchange Web Services.
@@ -1510,11 +1519,7 @@ public final class ExchangeService extends ExchangeServiceBase implements IAutod
       Attachment[] attachments, BodyType bodyType,
       Iterable<PropertyDefinitionBase> additionalProperties)
       throws Exception {
-    List<Attachment> attList = new ArrayList<Attachment>();
-    for (Attachment attachment : attachments) {
-      attList.add(attachment);
-    }
-    return this.internalGetAttachments(attList, bodyType,
+    return this.internalGetAttachments(Arrays.asList(attachments), bodyType,
         additionalProperties, ServiceErrorHandling.ReturnErrors);
   }
 
@@ -3202,13 +3207,8 @@ public final class ExchangeService extends ExchangeServiceBase implements IAutod
   public Collection<DelegateUserResponse> addDelegates(Mailbox mailbox,
       MeetingRequestsDeliveryScope meetingRequestsDeliveryScope,
       DelegateUser... delegateUsers) throws Exception {
-    ArrayList<DelegateUser> delUser = new ArrayList<DelegateUser>();
-    for (DelegateUser user : delegateUsers) {
-      delUser.add(user);
-    }
-
-    return this
-        .addDelegates(mailbox, meetingRequestsDeliveryScope, delUser);
+    return addDelegates(mailbox, meetingRequestsDeliveryScope,
+                        Arrays.asList(delegateUsers));
   }
 
   /**
@@ -3256,13 +3256,8 @@ public final class ExchangeService extends ExchangeServiceBase implements IAutod
   public Collection<DelegateUserResponse> updateDelegates(Mailbox mailbox,
       MeetingRequestsDeliveryScope meetingRequestsDeliveryScope,
       DelegateUser... delegateUsers) throws Exception {
-
-    ArrayList<DelegateUser> delUser = new ArrayList<DelegateUser>();
-    for (DelegateUser user : delegateUsers) {
-      delUser.add(user);
-    }
     return this.updateDelegates(mailbox, meetingRequestsDeliveryScope,
-        delUser);
+        Arrays.asList(delegateUsers));
   }
 
   /**
@@ -3310,11 +3305,7 @@ public final class ExchangeService extends ExchangeServiceBase implements IAutod
    */
   public Collection<DelegateUserResponse> removeDelegates(Mailbox mailbox,
       UserId... userIds) throws Exception {
-    ArrayList<UserId> delUser = new ArrayList<UserId>();
-    for (UserId user : userIds) {
-      delUser.add(user);
-    }
-    return this.removeDelegates(mailbox, delUser);
+    return removeDelegates(mailbox, Arrays.asList(userIds));
   }
 
   /**
@@ -3357,11 +3348,7 @@ public final class ExchangeService extends ExchangeServiceBase implements IAutod
    */
   public DelegateInformation getDelegates(Mailbox mailbox,
       boolean includePermissions, UserId... userIds) throws Exception {
-    ArrayList<UserId> delUser = new ArrayList<UserId>();
-    for (UserId user : userIds) {
-      delUser.add(user);
-    }
-    return this.getDelegates(mailbox, includePermissions, delUser);
+    return this.getDelegates(mailbox, includePermissions, Arrays.asList(userIds));
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/core/PropertySet.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/PropertySet.java
@@ -147,9 +147,7 @@ public final class PropertySet implements ISelfValidate,
       PropertyDefinitionBase... additionalProperties) {
     this.basePropertySet = basePropertySet;
     if (null != additionalProperties) {
-      for (PropertyDefinitionBase property : additionalProperties) {
-        this.additionalProperties.add(property);
-      }
+        this.additionalProperties.addAll(Arrays.asList(additionalProperties));
     }
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/Appointment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/Appointment.java
@@ -65,7 +65,7 @@ import microsoft.exchange.webservices.data.property.complex.RecurringAppointment
 import microsoft.exchange.webservices.data.property.complex.recurrence.pattern.Recurrence;
 import microsoft.exchange.webservices.data.property.complex.time.TimeZoneDefinition;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 
 /**
@@ -340,12 +340,7 @@ public class Appointment extends Item implements ICalendarActionProvider {
   public void forward(MessageBody bodyPrefix, EmailAddress... toRecipients)
       throws Exception {
     if (null != toRecipients) {
-      ArrayList<EmailAddress> list = new ArrayList<EmailAddress>();
-      for (EmailAddress email : toRecipients) {
-        list.add(email);
-      }
-
-      this.forward(bodyPrefix, list);
+      forward(bodyPrefix, Arrays.asList(toRecipients));
     }
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/EmailMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/EmailMessage.java
@@ -46,7 +46,7 @@ import microsoft.exchange.webservices.data.property.complex.ItemAttachment;
 import microsoft.exchange.webservices.data.property.complex.ItemId;
 import microsoft.exchange.webservices.data.property.complex.MessageBody;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 
 /**
  * Represents an e-mail message. Properties available on e-mail messages are
@@ -226,11 +226,7 @@ public class EmailMessage extends Item {
   public void forward(MessageBody bodyPrefix, EmailAddress... toRecipients)
       throws Exception {
     if (null != toRecipients) {
-      ArrayList<EmailAddress> list = new ArrayList<EmailAddress>();
-      for (EmailAddress email : toRecipients) {
-        list.add(email);
-      }
-      this.forward(bodyPrefix, list);
+      forward(bodyPrefix, Arrays.asList(toRecipients));
     }
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/PostItem.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/PostItem.java
@@ -41,9 +41,8 @@ import microsoft.exchange.webservices.data.property.complex.ItemAttachment;
 import microsoft.exchange.webservices.data.property.complex.ItemId;
 import microsoft.exchange.webservices.data.property.complex.MessageBody;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
-import java.util.List;
 
 /**
  * Represents a post item. Properties available on post item are defined in the
@@ -198,11 +197,7 @@ public final class PostItem extends Item {
    */
   public void forward(MessageBody bodyPrefix, EmailAddress... toRecipients)
       throws Exception {
-    List<EmailAddress> list = new ArrayList<EmailAddress>();
-    for (EmailAddress address : toRecipients) {
-      list.add(address);
-    }
-    this.forward(bodyPrefix, list);
+    forward(bodyPrefix, Arrays.asList(toRecipients));
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/ItemAttachment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/ItemAttachment.java
@@ -35,8 +35,7 @@ import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.ServiceValidationException;
 import microsoft.exchange.webservices.data.property.definition.PropertyDefinitionBase;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
 
 /**
  * Represents an item attachment.
@@ -201,13 +200,7 @@ public class ItemAttachment extends Attachment implements IServiceObjectChangedD
    */
   public void load(PropertyDefinitionBase... additionalProperties)
       throws Exception {
-    List<PropertyDefinitionBase> addProp =
-        new ArrayList<PropertyDefinitionBase>();
-
-    for (PropertyDefinitionBase addProperties1 : additionalProperties) {
-      addProp.add(addProperties1);
-    }
-    this.internalLoad(null /* bodyType */, addProp);
+    internalLoad(null /* bodyType */, Arrays.asList(additionalProperties));
   }
 
   /**
@@ -230,12 +223,7 @@ public class ItemAttachment extends Attachment implements IServiceObjectChangedD
    */
   public void load(BodyType bodyType,
       PropertyDefinitionBase... additionalProperties) throws Exception {
-    List<PropertyDefinitionBase> addProp =
-        new ArrayList<PropertyDefinitionBase>();
-    for (PropertyDefinitionBase addProperties1 : additionalProperties) {
-      addProp.add(addProperties1);
-    }
-    this.internalLoad(bodyType, addProp);
+    internalLoad(bodyType, Arrays.asList(additionalProperties));
   }
 
   /**


### PR DESCRIPTION
Just another performance optimization PR:

It is not optimal to re-create array lists manually. It works much faster with Arrays.asList:

```java
    public static <T> List<T> asList(T... a) {
	return new ArrayList<T>(a);
    }
```

As additional plus: we can write less code.