### PR TITLE
Reverting inadvertent namespace changes

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
@@ -164,7 +164,7 @@ public final class AutodiscoverService extends ExchangeServiceBase
    * The Constant AutodiscoverRequestNamespace.
    */
   private static final String AutodiscoverRequestNamespace =
-      "http://schema.microsoft.com/exchange/autodiscover/" +
+      "http://schemas.microsoft.com/exchange/autodiscover/" +
           "outlook/requestschema/2006";
   // Maximum number of Url (or address) redirections that will be followed by
   // an Autodiscover call

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/configuration/outlook/OutlookConfigurationSettings.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/configuration/outlook/OutlookConfigurationSettings.java
@@ -101,7 +101,7 @@ public final class OutlookConfigurationSettings extends ConfigurationSettingsBas
    * @return The namespace that defines the settings.
    */
   @Override public String getNamespace() {
-    return "http://schema.microsoft.com/exchange/" +
+    return "http://schemas.microsoft.com/exchange/" +
         "autodiscover/outlook/responseschema/2006a";
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsUtilities.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsUtilities.java
@@ -150,25 +150,25 @@ public class EwsUtilities {
    * The Constant EwsTypesNamespace.
    */
   public static final String EwsTypesNamespace =
-      "http://schema.microsoft.com/exchange/services/2006/types";
+      "http://schemas.microsoft.com/exchange/services/2006/types";
 
   /**
    * The Constant EwsMessagesNamespace.
    */
   public static final String EwsMessagesNamespace =
-      "http://schema.microsoft.com/exchange/services/2006/messages";
+      "http://schemas.microsoft.com/exchange/services/2006/messages";
 
   /**
    * The Constant EwsErrorsNamespace.
    */
   public static final String EwsErrorsNamespace =
-      "http://schema.microsoft.com/exchange/services/2006/errors";
+      "http://schemas.microsoft.com/exchange/services/2006/errors";
 
   /**
    * The Constant EwsSoapNamespace.
    */
   public static final String EwsSoapNamespace =
-      "http://schema.xmlsoap.org/soap/envelope/";
+      "http://schemas.xmlsoap.org/soap/envelope/";
 
   /**
    * The Constant EwsSoap12Namespace.
@@ -186,13 +186,13 @@ public class EwsUtilities {
    * The Constant PassportSoapFaultNamespace.
    */
   public static final String PassportSoapFaultNamespace =
-      "http://schema.microsoft.com/Passport/SoapServices/SOAPFault";
+      "http://schemas.microsoft.com/Passport/SoapServices/SOAPFault";
 
   /**
    * The Constant WSTrustFebruary2005Namespace.
    */
   public static final String WSTrustFebruary2005Namespace =
-      "http://schema.xmlsoap.org/ws/2005/02/trust";
+      "http://schemas.xmlsoap.org/ws/2005/02/trust";
 
   /**
    * The Constant WSAddressingNamespace.
@@ -205,7 +205,7 @@ public class EwsUtilities {
    * The Constant AutodiscoverSoapNamespace.
    */
   public static final String AutodiscoverSoapNamespace =
-      "http://schema.microsoft.com/exchange/2010/Autodiscover";
+      "http://schemas.microsoft.com/exchange/2010/Autodiscover";
 
   public static final String WSSecurityUtilityNamespace =
       "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";

--- a/src/main/java/microsoft/exchange/webservices/data/credential/WSSecurityBasedCredentials.java
+++ b/src/main/java/microsoft/exchange/webservices/data/credential/WSSecurityBasedCredentials.java
@@ -82,7 +82,7 @@ public abstract class WSSecurityBasedCredentials extends ExchangeCredentials {
    * The Constant WsAddressingHeadersFormat.
    */
   protected static final String wsAddressingHeadersFormat =
-      "<wsa:Action soap:mustUnderstand='1'>http://schema.microsoft.com/exchange/services/2006/messages/%s</wsa:Action>"
+      "<wsa:Action soap:mustUnderstand='1'>http://schemas.microsoft.com/exchange/services/2006/messages/%s</wsa:Action>"
           +
           "<wsa:ReplyTo><wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>" +
           "</wsa:ReplyTo>" +

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/MeetingTimeZone.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/MeetingTimeZone.java
@@ -25,7 +25,7 @@ package microsoft.exchange.webservices.data.property.complex;
 
 import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlWriter;
-import microsoft.exchange.webservices.data.core.EwsUtilities;;
+import microsoft.exchange.webservices.data.core.EwsUtilities;
 import microsoft.exchange.webservices.data.misc.TimeSpan;
 import microsoft.exchange.webservices.data.core.XmlAttributeNames;
 import microsoft.exchange.webservices.data.core.XmlElementNames;


### PR DESCRIPTION
Some inadvertent schema namespace changes have crept in through the commit 'https://github.com/OfficeDev/ews-java-api/commit/c57210dff0c8eb6cd7f7b23ae1e04e42fe516d42'.

This is to address https://github.com/OfficeDev/ews-java-api/issues/270