### PR TITLE
Adding editorconfig file to standardize code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+# 2 space indentation
+[*.java]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Adding editor config, a common way to standardize editor configurations for projects. This enforces two spaces for java files on most editors. Other code style rules can easily be added
http://editorconfig.org