### PR TITLE
Add jcl as logging facade

### DIFF
--- a/.idea/libraries/Maven__ch_qos_logback_logback_classic_1_1_3.xml
+++ b/.idea/libraries/Maven__ch_qos_logback_logback_classic_1_1_3.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: ch.qos.logback:logback-classic:1.1.3">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/ch/qos/logback/logback-classic/1.1.3/logback-classic-1.1.3.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/ch/qos/logback/logback-classic/1.1.3/logback-classic-1.1.3-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/ch/qos/logback/logback-classic/1.1.3/logback-classic-1.1.3-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__ch_qos_logback_logback_core_1_1_3.xml
+++ b/.idea/libraries/Maven__ch_qos_logback_logback_core_1_1_3.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: ch.qos.logback:logback-core:1.1.3">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/ch/qos/logback/logback-core/1.1.3/logback-core-1.1.3.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/ch/qos/logback/logback-core/1.1.3/logback-core-1.1.3-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/ch/qos/logback/logback-core/1.1.3/logback-core-1.1.3-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_fusesource_jansi_jansi_1_11.xml
+++ b/.idea/libraries/Maven__org_fusesource_jansi_jansi_1_11.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.fusesource.jansi:jansi:1.11">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/fusesource/jansi/jansi/1.11/jansi-1.11.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/fusesource/jansi/jansi/1.11/jansi-1.11-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/fusesource/jansi/jansi/1.11/jansi-1.11-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_slf4j_jcl_over_slf4j_1_7_12.xml
+++ b/.idea/libraries/Maven__org_slf4j_jcl_over_slf4j_1_7_12.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.slf4j:jcl-over-slf4j:1.7.12">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/jcl-over-slf4j/1.7.12/jcl-over-slf4j-1.7.12.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/jcl-over-slf4j/1.7.12/jcl-over-slf4j-1.7.12-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/jcl-over-slf4j/1.7.12/jcl-over-slf4j-1.7.12-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/.idea/libraries/Maven__org_slf4j_slf4j_api_1_7_12.xml
+++ b/.idea/libraries/Maven__org_slf4j_slf4j_api_1_7_12.xml
@@ -1,0 +1,13 @@
+<component name="libraryTable">
+  <library name="Maven: org.slf4j:slf4j-api:1.7.12">
+    <CLASSES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/1.7.12/slf4j-api-1.7.12.jar!/" />
+    </CLASSES>
+    <JAVADOC>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/1.7.12/slf4j-api-1.7.12-javadoc.jar!/" />
+    </JAVADOC>
+    <SOURCES>
+      <root url="jar://$MAVEN_REPOSITORY$/org/slf4j/slf4j-api/1.7.12/slf4j-api-1.7.12-sources.jar!/" />
+    </SOURCES>
+  </library>
+</component>

--- a/ews-java-api.iml
+++ b/ews-java-api.iml
@@ -6,6 +6,7 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />
@@ -21,5 +22,10 @@
     <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-all:1.3" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:1.10.19" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:2.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:slf4j-api:1.7.12" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: ch.qos.logback:logback-classic:1.1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: ch.qos.logback:logback-core:1.1.3" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:jcl-over-slf4j:1.7.12" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.fusesource.jansi:jansi:1.11" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,9 @@
         <junit.version>4.12</junit.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <mockito-core.version>1.10.19</mockito-core.version>
+        <slf4j.version>1.7.12</slf4j.version>
+        <logback.version>1.1.3</logback.version>
+        <jansi.version>1.11</jansi.version>
     </properties>
 
     <profiles>
@@ -211,6 +214,35 @@
             <version>${mockito-core.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.fusesource.jansi</groupId>
+            <artifactId>jansi</artifactId>
+            <version>${jansi.version}</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/request/AutodiscoverRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/request/AutodiscoverRequest.java
@@ -45,6 +45,8 @@ import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.security.XmlNodeType;
 import microsoft.exchange.webservices.data.autodiscover.AutodiscoverService;
 import microsoft.exchange.webservices.data.autodiscover.response.AutodiscoverResponse;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.*;
@@ -58,6 +60,9 @@ import java.util.zip.InflaterInputStream;
  * Represents the base class for all requested made to the Autodiscover service.
  */
 public abstract class AutodiscoverRequest {
+
+  private static final Log LOG = LogFactory.getLog(AutodiscoverRequest.class);
+
   /**
    * The service.
    */
@@ -169,7 +174,7 @@ public abstract class AutodiscoverRequest {
 			 * String decodedString;
 			 * 
 			 * while ((decodedString = in.readLine()) != null) {
-			 * System.out.println(decodedString); } in.close();
+			 * LOG.debug(decodedString); } in.close();
 			 */
 
       memoryStream = new ByteArrayOutputStream();
@@ -316,7 +321,7 @@ public abstract class AutodiscoverRequest {
           this.service.processHttpErrorResponse(req, exception);
         }
       } catch (Exception e) {
-        e.printStackTrace();
+        LOG.error(e);
       }
     }
   }
@@ -446,7 +451,7 @@ public abstract class AutodiscoverRequest {
       // If response doesn't contain a valid SOAP fault, just ignore
       // exception and
       // return null for SOAP fault details.
-      e.printStackTrace();
+      LOG.error(e);
     }
 
     return soapFaultDetails;

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/response/GetDomainSettingsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/response/GetDomainSettingsResponse.java
@@ -31,6 +31,8 @@ import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.security.XmlNodeType;
 import microsoft.exchange.webservices.data.autodiscover.exception.error.DomainSettingError;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,6 +43,8 @@ import java.util.Map;
  * Represents the response to a GetDomainSettings call for an individual domain.
  */
 public final class GetDomainSettingsResponse extends AutodiscoverResponse {
+
+  private static final Log LOG = LogFactory.getLog(GetDomainSettingsResponse.class);
 
   /**
    * The domain.
@@ -142,7 +146,7 @@ public final class GetDomainSettingsResponse extends AutodiscoverResponse {
           try {
             this.loadDomainSettingsFromXml(reader);
           } catch (Exception e) {
-            e.printStackTrace();
+            LOG.error(e);
           }
         } else {
           super.loadFromXml(reader, endElementName);

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceXmlReader.java
@@ -99,7 +99,7 @@ public class EwsServiceXmlReader extends EwsXmlReader {
       formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
       tempDate = formatter.parse(date);
     } catch (Exception e) {
-      //e.printStackTrace();
+      //LOG.error(e);
       DateFormat formatter = new SimpleDateFormat(
           "yyyy-MM-dd'T'HH:mm:ss.SSS");
       formatter.setTimeZone(TimeZone.getTimeZone("UTC"));

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceXmlWriter.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceXmlWriter.java
@@ -29,6 +29,8 @@ import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationExce
 import microsoft.exchange.webservices.data.interfaces.IDisposable;
 import microsoft.exchange.webservices.data.interfaces.ISearchStringProvider;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.*;
 
 import javax.xml.stream.XMLOutputFactory;
@@ -44,6 +46,8 @@ import java.util.Date;
  * Stax based XML Writer implementation.
  */
 public class EwsServiceXmlWriter implements IDisposable {
+
+  private static final Log LOG = LogFactory.getLog(EwsServiceXmlWriter.class);
 
   /**
    * The is disposed.
@@ -139,7 +143,7 @@ public class EwsServiceXmlWriter implements IDisposable {
       try {
         this.xmlWriter.close();
       } catch (XMLStreamException e) {
-        e.printStackTrace();
+        LOG.error(e);
       }
       this.isDisposed = true;
     }
@@ -503,7 +507,7 @@ public class EwsServiceXmlWriter implements IDisposable {
         bos.write(buf, 0, readNum);
       }
     } catch (IOException ex) {
-      ex.printStackTrace();
+      LOG.error(ex);
     } finally {
       bos.close();
     }

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsUtilities.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsUtilities.java
@@ -53,6 +53,8 @@ import microsoft.exchange.webservices.data.interfaces.ILazyMember;
 import microsoft.exchange.webservices.data.interfaces.IPredicate;
 import microsoft.exchange.webservices.data.interfaces.ISelfValidate;
 import microsoft.exchange.webservices.data.property.complex.ItemAttachment;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -80,6 +82,8 @@ import javax.xml.stream.XMLStreamWriter;
  * EWS utilities.
  */
 public class EwsUtilities {
+
+  private static final Log LOG = LogFactory.getLog(EwsUtilities.class);
 
   /**
    * The Constant XSFalse.
@@ -953,15 +957,15 @@ public class EwsUtilities {
     Pattern timeSpanParser = Pattern.compile("-P");
     Matcher m = timeSpanParser.matcher(xsDuration);
     boolean negative = false;
-    System.out.println(m.find());
+    LOG.debug(m.find());
     if (m.find()) {
       negative = true;
     }
-    System.out.println(m.group());
+    LOG.debug(m.group());
 
     // Year
     m = Pattern.compile("(\\d+)Y").matcher(xsDuration);
-    System.out.println(m.find());
+    LOG.debug(m.find());
     int year = 0;
     if (m.find()) {
       year = Integer.parseInt(m.group().substring(0,
@@ -970,7 +974,7 @@ public class EwsUtilities {
 
     // Month
     m = Pattern.compile("(\\d+)M").matcher(xsDuration);
-    System.out.println(m.find());
+    LOG.debug(m.find());
     int month = 0;
     if (m.find()) {
       month = Integer.parseInt(m.group().substring(0,
@@ -979,7 +983,7 @@ public class EwsUtilities {
 
     // Day
     m = Pattern.compile("(\\d+)D").matcher(xsDuration);
-    System.out.println(m.find());
+    LOG.debug(m.find());
     int day = 0;
     if (m.find()) {
       day = Integer.parseInt(m.group().substring(0,
@@ -988,7 +992,7 @@ public class EwsUtilities {
 
     // Hour
     m = Pattern.compile("(\\d+)H").matcher(xsDuration);
-    System.out.println(m.find());
+    LOG.debug(m.find());
     int hour = 0;
     if (m.find()) {
       hour = Integer.parseInt(m.group().substring(0,
@@ -997,7 +1001,7 @@ public class EwsUtilities {
 
     // Minute
     m = Pattern.compile("(\\d+)M").matcher(xsDuration);
-    System.out.println(m.find());
+    LOG.debug(m.find());
     int minute = 0;
     if (m.find()) {
       minute = Integer.parseInt(m.group().substring(0,
@@ -1006,7 +1010,7 @@ public class EwsUtilities {
 
     // Seconds
     m = Pattern.compile("(\\d+).").matcher(xsDuration);
-    System.out.println(m.find());
+    LOG.debug(m.find());
     int seconds = 0;
     if (m.find()) {
       seconds = Integer.parseInt(m.group().substring(0,
@@ -1015,7 +1019,7 @@ public class EwsUtilities {
 
     int milliseconds = 0;
     m = Pattern.compile("(\\d+)S").matcher(xsDuration);
-    System.out.println(m.find());
+    LOG.debug(m.find());
     if (m.find()) {
       // Only allowed 4 digits of precision
       if (m.group().length() > 5) {

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsXmlReader.java
@@ -28,6 +28,8 @@ import microsoft.exchange.webservices.data.security.XmlNodeType;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
@@ -41,6 +43,8 @@ import java.io.*;
  * Defines the EwsXmlReader class.
  */
 public class EwsXmlReader {
+
+  private static final Log LOG = LogFactory.getLog(EwsXmlReader.class);
 
   /**
    * The Read write buffer size.
@@ -954,12 +958,12 @@ public class EwsXmlReader {
       try {
         in = new ByteArrayInputStream(str.toString().getBytes("UTF-8"));
       } catch (UnsupportedEncodingException e) {
-        e.printStackTrace();
+        LOG.error(e);
       }
       eventReader = inputFactory.createXMLEventReader(in);
 
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
     return eventReader;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
@@ -180,6 +180,8 @@ import microsoft.exchange.webservices.data.sync.ChangeCollection;
 import microsoft.exchange.webservices.data.sync.FolderChange;
 import microsoft.exchange.webservices.data.sync.ItemChange;
 import microsoft.exchange.webservices.data.messaging.UnifiedMessaging;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
@@ -200,6 +202,8 @@ import java.util.TimeZone;
  * Represents a binding to the Exchange Web Services.
  */
 public final class ExchangeService extends ExchangeServiceBase implements IAutodiscoverRedirectionUrl {
+
+  private static final Log LOG = LogFactory.getLog(ExchangeService.class);
 
   /**
    * The url.
@@ -3800,7 +3804,7 @@ public final class ExchangeService extends ExchangeServiceBase implements IAutod
     try {
       this.url = this.adjustServiceUriFromCredentials(this.getUrl());
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
     return this.prepareHttpWebRequestForUrl(url, this
         .getAcceptGzipEncoding(), true);

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/DeleteAttachmentRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/DeleteAttachmentRequest.java
@@ -37,6 +37,8 @@ import microsoft.exchange.webservices.data.enumeration.ServiceErrorHandling;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.property.complex.Attachment;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,6 +48,8 @@ import java.util.List;
  */
 public final class DeleteAttachmentRequest extends
     MultiResponseServiceRequest<DeleteAttachmentResponse> {
+
+  private static final Log LOG = LogFactory.getLog(DeleteAttachmentRequest.class);
 
   /**
    * The attachments.
@@ -77,9 +81,9 @@ public final class DeleteAttachmentRequest extends
             String.format("Attachment[%d].Id ", i));
       }
     } catch (ServiceLocalException e) {
-      e.printStackTrace();
+      LOG.error(e);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/DeleteFolderRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/DeleteFolderRequest.java
@@ -32,12 +32,14 @@ import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.ServiceErrorHandling;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.misc.FolderIdWrapperList;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Represents a DeleteFolder request.
  */
 public final class DeleteFolderRequest extends DeleteRequest<ServiceResponse> {
-
+  private static final Log LOG = LogFactory.getLog(DeleteFolderRequest.class);
   /**
    * The folder ids.
    */
@@ -131,7 +133,7 @@ public final class DeleteFolderRequest extends DeleteRequest<ServiceResponse> {
       this.getFolderIds().writeToXml(writer, XmlNamespace.Messages,
           XmlElementNames.FolderIds);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/DeleteRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/DeleteRequest.java
@@ -30,6 +30,8 @@ import microsoft.exchange.webservices.data.core.XmlAttributeNames;
 import microsoft.exchange.webservices.data.enumeration.DeleteMode;
 import microsoft.exchange.webservices.data.enumeration.ServiceErrorHandling;
 import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Represents an abstract Delete request.
@@ -38,6 +40,8 @@ import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationExce
  */
 abstract class DeleteRequest<TResponse extends ServiceResponse> extends
     MultiResponseServiceRequest<TResponse> {
+
+  private static final Log LOG = LogFactory.getLog(DeleteRequest.class);
 
   /**
    * Delete mode. Default is SoftDelete.
@@ -72,7 +76,7 @@ abstract class DeleteRequest<TResponse extends ServiceResponse> extends
       writer.writeAttributeValue(XmlAttributeNames.DeleteType, this
           .getDeleteMode());
     } catch (ServiceXmlSerializationException e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/FindRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/FindRequest.java
@@ -37,6 +37,8 @@ import microsoft.exchange.webservices.data.misc.FolderIdWrapperList;
 import microsoft.exchange.webservices.data.search.Grouping;
 import microsoft.exchange.webservices.data.search.ViewBase;
 import microsoft.exchange.webservices.data.search.filter.SearchFilter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Represents an abstract Find request.
@@ -45,6 +47,8 @@ import microsoft.exchange.webservices.data.search.filter.SearchFilter;
  */
 abstract class FindRequest<TResponse extends ServiceResponse> extends
     MultiResponseServiceRequest<TResponse> {
+
+  private static final Log LOG = LogFactory.getLog(FindRequest.class);
 
   /**
    * The parent folder ids.
@@ -166,7 +170,7 @@ abstract class FindRequest<TResponse extends ServiceResponse> extends
       this.getParentFolderIds().writeToXml(writer, XmlNamespace.Messages,
           XmlElementNames.ParentFolderIds);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
 
     if (!(this.queryString == null || this.queryString.isEmpty())) {

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/HangingServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/HangingServiceRequestBase.java
@@ -37,6 +37,8 @@ import microsoft.exchange.webservices.data.exception.ServiceVersionException;
 import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
 import microsoft.exchange.webservices.data.exception.XmlException;
 import microsoft.exchange.webservices.data.misc.HangingTraceStream;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayOutputStream;
@@ -56,6 +58,8 @@ import java.util.concurrent.TimeUnit;
  * Represents an abstract, hanging service request.
  */
 public abstract class HangingServiceRequestBase<T> extends ServiceRequestBase<T> {
+
+  private static final Log LOG = LogFactory.getLog(HangingServiceRequestBase.class);
 
   public interface IHandleResponseObject {
 
@@ -247,7 +251,7 @@ public abstract class HangingServiceRequestBase<T> extends ServiceRequestBase<T>
       this.disconnect(HangingRequestDisconnectReason.Exception, ex);
       return;
     } catch (UnsupportedOperationException ex) {
-      ex.printStackTrace();
+      LOG.error(ex);
       // This is thrown if we close the stream during a
       //read operation due to a user method call.
       // Trying to delay closing until the read finishes
@@ -264,7 +268,7 @@ public abstract class HangingServiceRequestBase<T> extends ServiceRequestBase<T>
           responseCopy.close();
           responseCopy = null;
         } catch (Exception ex) {
-          ex.printStackTrace();
+          LOG.error(ex);
         }
       }
     }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/MoveCopyFolderRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/MoveCopyFolderRequest.java
@@ -32,6 +32,8 @@ import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.enumeration.ServiceErrorHandling;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.misc.FolderIdWrapperList;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Represents an abstract Move/Copy Folder request.
@@ -40,6 +42,8 @@ import microsoft.exchange.webservices.data.misc.FolderIdWrapperList;
  */
 abstract class MoveCopyFolderRequest<TResponse extends ServiceResponse> extends
     MoveCopyRequest<Folder, TResponse> {
+
+  private static final Log LOG = LogFactory.getLog(MoveCopyFolderRequest.class);
 
   /**
    * The folder ids.
@@ -84,7 +88,7 @@ abstract class MoveCopyFolderRequest<TResponse extends ServiceResponse> extends
       this.folderIds.writeToXml(writer, XmlNamespace.Messages,
           XmlElementNames.FolderIds);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
@@ -47,6 +47,8 @@ import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationEx
 import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
 import microsoft.exchange.webservices.data.exception.XmlException;
 import microsoft.exchange.webservices.data.misc.SoapFaultDetails;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.ws.http.HTTPException;
@@ -58,6 +60,8 @@ import java.util.zip.InflaterInputStream;
  * Represents an abstract service request.
  */
 public abstract class ServiceRequestBase<T> {
+
+  private static final Log LOG = LogFactory.getLog(ServiceRequestBase.class);
 
   // Private Constants
   // private final String XMLSchemaNamespace =
@@ -698,7 +702,7 @@ public abstract class ServiceRequestBase<T> {
       // If response doesn't contain a valid SOAP fault, just ignore
       // exception and
       // return null for SOAP fault details.
-      e.printStackTrace();
+      LOG.error(e);
     }
 
     return soapFaultDetails;

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/CreateResponseObjectResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/CreateResponseObjectResponse.java
@@ -28,11 +28,15 @@ import microsoft.exchange.webservices.data.core.ExchangeService;
 import microsoft.exchange.webservices.data.core.service.item.Item;
 import microsoft.exchange.webservices.data.attribute.EditorBrowsable;
 import microsoft.exchange.webservices.data.enumeration.EditorBrowsableState;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Represents response to generic Create request.
  */
 @EditorBrowsable(state = EditorBrowsableState.Never) public final class CreateResponseObjectResponse extends CreateItemResponseBase {
+
+  private static final Log LOG = LogFactory.getLog(CreateResponseObjectResponse.class);
 
   /**
    * Gets Item instance.
@@ -48,10 +52,10 @@ import microsoft.exchange.webservices.data.enumeration.EditorBrowsableState;
     try {
       return EwsUtilities.createEwsObjectFromXmlElementName(Item.class, service, xmlElementName);
     } catch (InstantiationException e) {
-      e.printStackTrace();
+      LOG.error(e);
       return null;
     } catch (IllegalAccessException e) {
-      e.printStackTrace();
+      LOG.error(e);
       return null;
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/MoveCopyFolderResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/MoveCopyFolderResponse.java
@@ -31,6 +31,8 @@ import microsoft.exchange.webservices.data.core.service.ServiceObject;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.interfaces.IGetObjectInstanceDelegate;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.util.List;
 
@@ -40,6 +42,8 @@ import java.util.List;
  */
 public final class MoveCopyFolderResponse extends ServiceResponse implements
                                                                   IGetObjectInstanceDelegate<ServiceObject> {
+
+  private static final Log LOG = LogFactory.getLog(MoveCopyFolderResponse.class);
 
   /**
    * The folder.
@@ -87,7 +91,7 @@ public final class MoveCopyFolderResponse extends ServiceResponse implements
 
       this.folder = folders.get(0);
     } catch (ServiceLocalException e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
 
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/folder/Folder.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/folder/Folder.java
@@ -57,6 +57,8 @@ import microsoft.exchange.webservices.data.search.Grouping;
 import microsoft.exchange.webservices.data.search.ItemView;
 import microsoft.exchange.webservices.data.search.ViewBase;
 import microsoft.exchange.webservices.data.search.filter.SearchFilter;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -66,6 +68,8 @@ import java.util.EnumSet;
  */
 @ServiceObjectDefinition(xmlElementName = XmlElementNames.Folder)
 public class Folder extends ServiceObject {
+
+  private static final Log LOG = LogFactory.getLog(Folder.class);
 
   /**
    * Initializes an unsaved local instance of <see cref="Folder"/>.
@@ -158,7 +162,7 @@ public class Folder extends ServiceObject {
         this.getPermissions().validate();
       }
     } catch (ServiceLocalException e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
   }
 
@@ -238,7 +242,7 @@ public class Folder extends ServiceObject {
     try {
       this.throwIfThisIsNew();
     } catch (InvalidOperationException e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
 
     this.getService().deleteFolder(this.getId(), deleteMode);
@@ -623,7 +627,7 @@ public class Folder extends ServiceObject {
       return getPropertyBag().getObjectFromPropertyDefinition(
           getIdPropertyDefinition());
     } catch (ServiceLocalException e) {
-      e.printStackTrace();
+      LOG.error(e);
       return null;
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/MeetingCancellation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/MeetingCancellation.java
@@ -33,6 +33,8 @@ import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.misc.CalendarActionResults;
 import microsoft.exchange.webservices.data.property.complex.ItemAttachment;
 import microsoft.exchange.webservices.data.property.complex.ItemId;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Represents a meeting cancellation message. Properties available on meeting
@@ -40,6 +42,8 @@ import microsoft.exchange.webservices.data.property.complex.ItemId;
  */
 @ServiceObjectDefinition(xmlElementName = XmlElementNames.MeetingCancellation)
 public class MeetingCancellation extends MeetingMessage {
+
+  private static final Log LOG = LogFactory.getLog(MeetingCancellation.class);
 
   /**
    * Initializes a new instance of the class.
@@ -79,7 +83,7 @@ public class MeetingCancellation extends MeetingMessage {
       return service.bindToItem(MeetingCancellation.class, id,
           propertySet);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
       return null;
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/MeetingRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/MeetingRequest.java
@@ -51,6 +51,8 @@ import microsoft.exchange.webservices.data.property.complex.OccurrenceInfo;
 import microsoft.exchange.webservices.data.property.complex.OccurrenceInfoCollection;
 import microsoft.exchange.webservices.data.property.complex.recurrence.pattern.Recurrence;
 import microsoft.exchange.webservices.data.property.complex.time.TimeZoneDefinition;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.util.Date;
 
@@ -61,6 +63,8 @@ import java.util.Date;
  */
 @ServiceObjectDefinition(xmlElementName = XmlElementNames.MeetingRequest)
 public class MeetingRequest extends MeetingMessage implements ICalendarActionProvider {
+
+  private static final Log LOG = LogFactory.getLog(MeetingRequest.class);
 
   /**
    * Initializes a new instance of the class.
@@ -97,7 +101,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
     try {
       return service.bindToItem(MeetingRequest.class, id, propertySet);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
       return null;
     }
   }
@@ -148,7 +152,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
     try {
       return new AcceptMeetingInvitationMessage(this, tentative);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
       return null;
     }
   }
@@ -164,7 +168,7 @@ public class MeetingRequest extends MeetingMessage implements ICalendarActionPro
     try {
       return new DeclineMeetingInvitationMessage(this);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
       return null;
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/MeetingResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/MeetingResponse.java
@@ -30,6 +30,8 @@ import microsoft.exchange.webservices.data.attribute.ServiceObjectDefinition;
 import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.property.complex.ItemAttachment;
 import microsoft.exchange.webservices.data.property.complex.ItemId;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Represents a response to a meeting request. Properties available on meeting
@@ -37,6 +39,8 @@ import microsoft.exchange.webservices.data.property.complex.ItemId;
  */
 @ServiceObjectDefinition(xmlElementName = XmlElementNames.MeetingResponse)
 public class MeetingResponse extends MeetingMessage {
+
+  private static final Log LOG = LogFactory.getLog(MeetingResponse.class);
 
   /**
    * Initializes a new instance of the class.
@@ -74,7 +78,7 @@ public class MeetingResponse extends MeetingMessage {
     try {
       return service.bindToItem(MeetingResponse.class, id, propertySet);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
       return null;
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/schema/ServiceObjectSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/schema/ServiceObjectSchema.java
@@ -38,6 +38,8 @@ import microsoft.exchange.webservices.data.property.definition.ComplexPropertyDe
 import microsoft.exchange.webservices.data.property.definition.IndexedPropertyDefinition;
 import microsoft.exchange.webservices.data.property.definition.PropertyDefinition;
 import microsoft.exchange.webservices.data.property.definition.PropertyDefinitionBase;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
@@ -50,10 +52,12 @@ import java.util.*;
 public abstract class ServiceObjectSchema implements
     Iterable<PropertyDefinition> {
 
+  private static final Log LOG = LogFactory.getLog(ServiceObjectSchema.class);
+
   /**
    * The lock object.
    */
-  private static Object lockObject = new Object();
+  private static final Object lockObject = new Object();
 
   /**
    * List of all schema types. If you add a new ServiceObject subclass that
@@ -176,11 +180,11 @@ public abstract class ServiceObjectSchema implements
             }
           }
         } catch (IllegalArgumentException e) {
-          e.printStackTrace();
+          LOG.error(e);
 
           // Skip the field
         } catch (IllegalAccessException e) {
-          e.printStackTrace();
+          LOG.error(e);
 
           // Skip the field
         }
@@ -212,11 +216,11 @@ public abstract class ServiceObjectSchema implements
                 .getName());
           }
         } catch (IllegalArgumentException e) {
-          e.printStackTrace();
+          LOG.error(e);
 
           // Skip the field
         } catch (IllegalAccessException e) {
-          e.printStackTrace();
+          LOG.error(e);
 
           // Skip the field
         }
@@ -261,11 +265,11 @@ public abstract class ServiceObjectSchema implements
                 propertyDefinition.setName(field.getName());
               }
             } catch (IllegalArgumentException e) {
-              e.printStackTrace();
+              LOG.error(e);
 
               // Skip the field
             } catch (IllegalAccessException e) {
-              e.printStackTrace();
+              LOG.error(e);
 
               // Skip the field
             }

--- a/src/main/java/microsoft/exchange/webservices/data/misc/AbstractAsyncCallback.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/AbstractAsyncCallback.java
@@ -23,9 +23,15 @@
 
 package microsoft.exchange.webservices.data.misc;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import java.util.concurrent.Future;
 
 public abstract class AbstractAsyncCallback implements Runnable, Callback<Object> {
+
+  private static final Log LOG = LogFactory.getLog(AbstractAsyncCallback.class);
+
   Future<?> task;
   static boolean callbackProcessed = false;
 
@@ -46,7 +52,7 @@ public abstract class AbstractAsyncCallback implements Runnable, Callback<Object
           Thread.sleep(1000);
         } catch (InterruptedException e) {
           // TODO Auto-generated catch block
-          e.printStackTrace();
+          LOG.error(e);
         }
         break;
       }

--- a/src/main/java/microsoft/exchange/webservices/data/misc/AsyncCallbackImplementation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/AsyncCallbackImplementation.java
@@ -23,13 +23,18 @@
 
 package microsoft.exchange.webservices.data.misc;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import java.util.concurrent.Future;
 
 public class AsyncCallbackImplementation extends AsyncCallback {
 
+  private static final Log LOG = LogFactory.getLog(AsyncCallbackImplementation.class);
+
   @Override
   public Object processMe(Future<?> task) {
-    System.out.println("In Async Callback" + task.isDone());
+    LOG.debug("In Async Callback" + task.isDone());
     return null;
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/misc/CallableMethod.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/CallableMethod.java
@@ -27,11 +27,16 @@ import microsoft.exchange.webservices.data.core.request.HttpClientWebRequest;
 import microsoft.exchange.webservices.data.core.request.HttpWebRequest;
 import microsoft.exchange.webservices.data.exception.EWSHttpException;
 import microsoft.exchange.webservices.data.exception.HttpErrorException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
 
 public class CallableMethod implements Callable<Object> {
+
+  private static final Log LOG = LogFactory.getLog(CallableMethod.class);
+
   HttpWebRequest request;
 
   public CallableMethod(HttpWebRequest request) {
@@ -50,13 +55,13 @@ public class CallableMethod implements Callable<Object> {
       return executeMethod();
     } catch (EWSHttpException e) {
       // TODO Auto-generated catch block
-      e.printStackTrace();
+      LOG.error(e);
     } catch (HttpErrorException e) {
       // TODO Auto-generated catch block
-      e.printStackTrace();
+      LOG.error(e);
     } catch (IOException e) {
       // TODO Auto-generated catch block
-      e.printStackTrace();
+      LOG.error(e);
     }
     return request;
   }

--- a/src/main/java/microsoft/exchange/webservices/data/misc/ConversationAction.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/ConversationAction.java
@@ -32,6 +32,8 @@ import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ArgumentException;
 import microsoft.exchange.webservices.data.property.complex.ConversationId;
 import microsoft.exchange.webservices.data.property.complex.StringList;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.util.Date;
 
@@ -43,6 +45,8 @@ import java.util.Date;
  * be taken on a conversation.
  */
 public class ConversationAction {
+
+  private static final Log LOG = LogFactory.getLog(ConversationAction.class);
 
   private ConversationActionType action;
   private ConversationId conversationId;
@@ -382,7 +386,7 @@ public class ConversationAction {
         }
       }
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
     } finally {
       writer.writeEndElement();
     }

--- a/src/main/java/microsoft/exchange/webservices/data/misc/HangingTraceStream.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/HangingTraceStream.java
@@ -26,6 +26,8 @@ package microsoft.exchange.webservices.data.misc;
 import microsoft.exchange.webservices.data.core.ExchangeService;
 import microsoft.exchange.webservices.data.core.request.HangingServiceRequestBase;
 import microsoft.exchange.webservices.data.enumeration.TraceFlags;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayOutputStream;
@@ -37,6 +39,8 @@ import java.io.InputStream;
  * That trace may be retrieved at the end of the stream.
  */
 public class HangingTraceStream extends InputStream {
+
+  private static final Log LOG = LogFactory.getLog(HangingTraceStream.class);
 
   private InputStream underlyingStream;
   private ExchangeService service;
@@ -126,7 +130,7 @@ public class HangingTraceStream extends InputStream {
             TraceFlags.DebugMessage,
             logMessage);
       } catch (XMLStreamException e) {
-        e.printStackTrace();
+        LOG.error(e);
       }
     }
 

--- a/src/main/java/microsoft/exchange/webservices/data/misc/MapiTypeConverter.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/MapiTypeConverter.java
@@ -30,6 +30,8 @@ import microsoft.exchange.webservices.data.exception.FormatException;
 import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
 import microsoft.exchange.webservices.data.interfaces.IFunction;
 import microsoft.exchange.webservices.data.interfaces.ILazyMember;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -45,6 +47,8 @@ import java.util.UUID;
  * Utility class to convert between MAPI Property type values and strings.
  */
 public class MapiTypeConverter {
+
+  private static final Log LOG = LogFactory.getLog(MapiTypeConverter.class);
 
   private static final IFunction<String, Object> DATE_TIME_PARSER = new IFunction<String, Object>() {
     public Object func(final String s) {
@@ -297,7 +301,7 @@ public class MapiTypeConverter {
         try {
           dt = utcFormatter.parse(s);
         } catch (ParseException e1) {
-          e.printStackTrace();
+          LOG.error(e);
           throw new IllegalArgumentException(
               errMsg, e);
         }

--- a/src/main/java/microsoft/exchange/webservices/data/misc/MapiTypeConverterMapEntry.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/MapiTypeConverterMapEntry.java
@@ -31,6 +31,8 @@ import microsoft.exchange.webservices.data.exception.FormatException;
 import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
 import microsoft.exchange.webservices.data.interfaces.IFunction;
 import microsoft.exchange.webservices.data.interfaces.ILazyMember;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -45,6 +47,8 @@ import java.util.UUID;
  * Represents an entry in the MapiTypeConverter map.
  */
 public class MapiTypeConverterMapEntry {
+
+  private static final Log LOG = LogFactory.getLog(MapiTypeConverterMapEntry.class);
 
   /**
    * Map CLR types used for MAPI property to matching default values.
@@ -66,7 +70,7 @@ public class MapiTypeConverterMapEntry {
           try {
             map.put(Date.class, formatter.parse("0001-01-01 12:00:00"));
           } catch (ParseException e) {
-            e.printStackTrace();
+            LOG.error(e);
           }
           map.put(UUID.class, UUID.fromString("00000000-0000-0000-0000-000000000000"));
           map.put(String.class, null);

--- a/src/main/java/microsoft/exchange/webservices/data/misc/SoapFaultDetails.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/SoapFaultDetails.java
@@ -31,6 +31,8 @@ import microsoft.exchange.webservices.data.security.XmlNodeType;
 import microsoft.exchange.webservices.data.enumeration.ServiceError;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import javax.xml.stream.XMLStreamException;
 import java.util.HashMap;
@@ -40,6 +42,8 @@ import java.util.Map;
  * Represents SoapFault details.
  */
 public class SoapFaultDetails {
+
+  private static final Log LOG = LogFactory.getLog(SoapFaultDetails.class);
 
   /**
    * The fault code.
@@ -151,7 +155,7 @@ public class SoapFaultDetails {
             this.setResponseCode(reader
                 .readElementValue(ServiceError.class));
           } catch (Exception e) {
-            e.printStackTrace();
+            LOG.error(e);
 
             // ServiceError couldn't be mapped to enum value, treat
             // as an ISE
@@ -175,7 +179,7 @@ public class SoapFaultDetails {
             this.setErrorCode(reader
                 .readElementValue(ServiceError.class));
           } catch (Exception e) {
-            e.printStackTrace();
+            LOG.error(e);
 
             // ServiceError couldn't be mapped to enum value, treat
             // as an ISE
@@ -189,7 +193,7 @@ public class SoapFaultDetails {
           try {
             this.setExceptionType(reader.readElementValue());
           } catch (Exception e) {
-            e.printStackTrace();
+            LOG.error(e);
             this.setExceptionType(null);
           }
         } else if (localName.equals(XmlElementNames.MessageXml)) {

--- a/src/main/java/microsoft/exchange/webservices/data/misc/TimeSpan.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/TimeSpan.java
@@ -24,11 +24,15 @@
 package microsoft.exchange.webservices.data.misc;
 
 import microsoft.exchange.webservices.data.exception.FormatException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * The Class TimeSpan.
  */
 public class TimeSpan implements Comparable<TimeSpan>, java.io.Serializable, Cloneable {
+
+  private static final Log LOG = LogFactory.getLog(TimeSpan.class);
 
   /**
    * Constant serialized ID used for compatibility.
@@ -221,7 +225,7 @@ public class TimeSpan implements Comparable<TimeSpan>, java.io.Serializable, Clo
     try {
       return super.clone();
     } catch (CloneNotSupportedException e) {
-      e.printStackTrace();
+      LOG.error(e);
       throw new InternalError();
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/misc/UserConfiguration.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/UserConfiguration.java
@@ -41,6 +41,8 @@ import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationExce
 import microsoft.exchange.webservices.data.property.complex.FolderId;
 import microsoft.exchange.webservices.data.property.complex.ItemId;
 import microsoft.exchange.webservices.data.property.complex.UserConfigurationDictionary;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.commons.codec.binary.Base64;
 
 import javax.xml.stream.XMLStreamException;
@@ -51,6 +53,8 @@ import java.util.EnumSet;
  * settings.
  */
 public class UserConfiguration {
+
+  private static final Log LOG = LogFactory.getLog(UserConfiguration.class);
 
   /**
    * The object version.
@@ -660,7 +664,7 @@ public class UserConfiguration {
     try {
       this.updatedProperties = EnumSet.of(NoProperties);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
     this.dictionary.setIsDirty(false);
   }

--- a/src/main/java/microsoft/exchange/webservices/data/notification/StreamingSubscriptionConnection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/notification/StreamingSubscriptionConnection.java
@@ -36,6 +36,8 @@ import microsoft.exchange.webservices.data.exception.ArgumentException;
 import microsoft.exchange.webservices.data.exception.ArgumentOutOfRangeException;
 import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.ServiceResponseException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -49,6 +51,8 @@ import java.util.Map;
 public final class StreamingSubscriptionConnection implements Closeable,
                                                               HangingServiceRequestBase.IHandleResponseObject,
     HangingServiceRequestBase.IHangingRequestDisconnectHandler {
+
+  private static final Log LOG = LogFactory.getLog(StreamingSubscriptionConnection.class);
 
   /**
    * Mapping of streaming id to subscriptions currently on the connection.
@@ -342,7 +346,7 @@ public final class StreamingSubscriptionConnection implements Closeable,
         // doing the necessary cleanup.
         this.currentHangingRequest.disconnect();
       } catch (Exception e) {
-        e.printStackTrace();
+        LOG.error(e);
       }
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/Attachment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/Attachment.java
@@ -34,6 +34,8 @@ import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceVersionException;
 import microsoft.exchange.webservices.data.property.definition.PropertyDefinitionBase;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.util.Date;
 
@@ -41,6 +43,8 @@ import java.util.Date;
  * Represents an attachment to an item.
  */
 public abstract class Attachment extends ComplexProperty {
+
+  private static final Log LOG = LogFactory.getLog(Attachment.class);
 
   /**
    * The owner.
@@ -315,7 +319,7 @@ public abstract class Attachment extends ComplexProperty {
         try {
           this.id = reader.readAttributeValue(XmlAttributeNames.Id);
         } catch (Exception e) {
-          e.printStackTrace();
+          LOG.error(e);
           return false;
         }
         if (this.getOwner() != null) {
@@ -363,7 +367,7 @@ public abstract class Attachment extends ComplexProperty {
         return false;
       }
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
       return false;
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/DeletedOccurrenceInfo.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/DeletedOccurrenceInfo.java
@@ -26,6 +26,8 @@ package microsoft.exchange.webservices.data.property.complex;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import javax.xml.stream.XMLStreamException;
 import java.util.Date;
@@ -35,6 +37,9 @@ import java.util.Date;
  * appointment.
  */
 public class DeletedOccurrenceInfo extends ComplexProperty {
+
+  private static final Log LOG = LogFactory.getLog(DeletedOccurrenceInfo.class);
+
   /**
    * The original start date and time of the deleted occurrence. The EWS
    * schema contains a Start property for deleted occurrences but it's really
@@ -62,9 +67,9 @@ public class DeletedOccurrenceInfo extends ComplexProperty {
       try {
         this.originalStart = reader.readElementValueAsDateTime();
       } catch (ServiceXmlDeserializationException e) {
-        e.printStackTrace();
+        LOG.error(e);
       } catch (XMLStreamException e) {
-        e.printStackTrace();
+        LOG.error(e);
       }
       return true;
     } else {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/EmailAddress.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/EmailAddress.java
@@ -30,11 +30,15 @@ import microsoft.exchange.webservices.data.interfaces.ISearchStringProvider;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.enumeration.MailboxType;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Represents an e-mail address.
  */
 public class EmailAddress extends ComplexProperty implements ISearchStringProvider {
+
+  private static final Log LOG = LogFactory.getLog(EmailAddress.class);
 
   // SMTP routing type.
   /**
@@ -315,7 +319,7 @@ public class EmailAddress extends ComplexProperty implements ISearchStringProvid
         return false;
       }
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
       return false;
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/FolderPermission.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/FolderPermission.java
@@ -37,6 +37,8 @@ import microsoft.exchange.webservices.data.enumeration.StandardUser;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.ServiceValidationException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -49,6 +51,7 @@ import java.util.Map.Entry;
  */
 public final class FolderPermission extends ComplexProperty implements IComplexPropertyChangedDelegate {
 
+  private static final Log LOG = LogFactory.getLog(FolderPermission.class);
 
   private static LazyMember<Map<FolderPermissionLevel, FolderPermission>>
       defaultPermissions =
@@ -255,7 +258,7 @@ public final class FolderPermission extends ComplexProperty implements IComplexP
                 results.add(permission);
 
               } catch (CloneNotSupportedException e) {
-                e.printStackTrace();
+                LOG.error(e);
               }
               return results;
             }

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/FolderPermissionCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/FolderPermissionCollection.java
@@ -32,6 +32,8 @@ import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.ServiceValidationException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,6 +43,8 @@ import java.util.Iterator;
  * Represents a collection of folder permissions.
  */
 public final class FolderPermissionCollection extends ComplexPropertyCollection<FolderPermission> {
+
+  private static final Log LOG = LogFactory.getLog(FolderPermissionCollection.class);
 
   /**
    * The is calendar folder.
@@ -136,9 +140,9 @@ public final class FolderPermissionCollection extends ComplexPropertyCollection<
       try {
         permission.validate(this.isCalendarFolder, permissionIndex);
       } catch (ServiceValidationException e) {
-        e.printStackTrace();
+        LOG.error(e);
       } catch (ServiceLocalException e) {
-        e.printStackTrace();
+        LOG.error(e);
       }
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/ItemAttachment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/ItemAttachment.java
@@ -34,6 +34,8 @@ import microsoft.exchange.webservices.data.enumeration.BodyType;
 import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.ServiceValidationException;
 import microsoft.exchange.webservices.data.property.definition.PropertyDefinitionBase;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.util.Arrays;
 
@@ -41,6 +43,8 @@ import java.util.Arrays;
  * Represents an item attachment.
  */
 public class ItemAttachment extends Attachment implements IServiceObjectChangedDelegate {
+
+  private static final Log LOG = LogFactory.getLog(ItemAttachment.class);
 
   /**
    * The item.
@@ -121,7 +125,7 @@ public class ItemAttachment extends Attachment implements IServiceObjectChangedD
         try {
           this.item.loadFromXml(reader, true /* clearPropertyBag */);
         } catch (Exception e) {
-          e.printStackTrace();
+          LOG.error(e);
 
         }
       }
@@ -173,7 +177,7 @@ public class ItemAttachment extends Attachment implements IServiceObjectChangedD
     try {
       this.item.writeToXml(writer);
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
 
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/ItemCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/ItemCollection.java
@@ -32,6 +32,8 @@ import microsoft.exchange.webservices.data.enumeration.EditorBrowsableState;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceObjectPropertyException;
 import microsoft.exchange.webservices.data.exception.ServiceVersionException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -45,6 +47,8 @@ import java.util.List;
 @EditorBrowsable(state = EditorBrowsableState.Never)
 public final class ItemCollection<TItem extends Item> extends ComplexProperty
     implements Iterable<TItem> {
+
+  private static final Log LOG = LogFactory.getLog(ItemCollection.class);
 
   /**
    * The item.
@@ -83,9 +87,9 @@ public final class ItemCollection<TItem extends Item> extends ComplexProperty
               item.loadFromXml(reader,
                   true /* clearPropertyBag */);
             } catch (ServiceObjectPropertyException e) {
-              e.printStackTrace();
+              LOG.error(e);
             } catch (ServiceVersionException e) {
-              e.printStackTrace();
+              LOG.error(e);
             }
 
             this.items.add(item);

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/MeetingTimeZone.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/MeetingTimeZone.java
@@ -32,11 +32,15 @@ import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
 import microsoft.exchange.webservices.data.property.complex.time.TimeZoneDefinition;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Represents a time zone in which a meeting is defined.
  */
 public final class MeetingTimeZone extends ComplexProperty {
+
+  private static final Log LOG = LogFactory.getLog(MeetingTimeZone.class);
 
   /**
    * The name.
@@ -181,7 +185,7 @@ public final class MeetingTimeZone extends ComplexProperty {
       result.setId(this.getName());
     } catch (Exception e) {
       // Could not find a time zone with that Id on the local system.
-      e.printStackTrace();
+      LOG.error(e);
     }
 
     // Again, we cannot accurately convert MeetingTimeZone into TimeZoneInfo

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/TimeChange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/TimeChange.java
@@ -32,6 +32,8 @@ import microsoft.exchange.webservices.data.core.XmlAttributeNames;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -40,6 +42,8 @@ import java.util.Date;
  * Represents a change of time for a time zone.
  */
 public final class TimeChange extends ComplexProperty {
+
+  private static final Log LOG = LogFactory.getLog(TimeChange.class);
 
   /**
    * The time zone name.
@@ -253,7 +257,7 @@ public final class TimeChange extends ComplexProperty {
       writer.writeAttributeValue(XmlAttributeNames.TimeZoneName,
           this.timeZoneName);
     } catch (ServiceXmlSerializationException e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/search/FolderView.java
+++ b/src/main/java/microsoft/exchange/webservices/data/search/FolderView.java
@@ -30,11 +30,15 @@ import microsoft.exchange.webservices.data.enumeration.FolderTraversal;
 import microsoft.exchange.webservices.data.enumeration.OffsetBasePoint;
 import microsoft.exchange.webservices.data.enumeration.ServiceObjectType;
 import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 /**
  * Represents the view settings in a folder search operation.
  */
 public final class FolderView extends PagedView {
+
+  private static final Log LOG = LogFactory.getLog(FolderView.class);
 
   /**
    * The traversal.
@@ -71,7 +75,7 @@ public final class FolderView extends PagedView {
       writer.writeAttributeValue(XmlAttributeNames.Traversal, this
           .getTraversal());
     } catch (ServiceXmlSerializationException e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/search/Grouping.java
+++ b/src/main/java/microsoft/exchange/webservices/data/search/Grouping.java
@@ -33,6 +33,8 @@ import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
 import microsoft.exchange.webservices.data.interfaces.ISelfValidate;
 import microsoft.exchange.webservices.data.property.definition.PropertyDefinitionBase;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -40,6 +42,8 @@ import javax.xml.stream.XMLStreamException;
  * Represents grouping options in item search operations.
  */
 public final class Grouping implements ISelfValidate {
+
+  private static final Log LOG = LogFactory.getLog(Grouping.class);
 
   /**
    * The sort direction.
@@ -208,7 +212,7 @@ public final class Grouping implements ISelfValidate {
     try {
       this.internalValidate();
     } catch (Exception e) {
-      e.printStackTrace();
+      LOG.error(e);
     }
 
   }

--- a/src/main/java/microsoft/exchange/webservices/data/search/filter/SearchFilter.java
+++ b/src/main/java/microsoft/exchange/webservices/data/search/filter/SearchFilter.java
@@ -41,6 +41,8 @@ import microsoft.exchange.webservices.data.interfaces.IComplexPropertyChangedDel
 import microsoft.exchange.webservices.data.interfaces.ISearchStringProvider;
 import microsoft.exchange.webservices.data.property.complex.ComplexProperty;
 import microsoft.exchange.webservices.data.property.definition.PropertyDefinitionBase;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 import javax.xml.stream.XMLStreamException;
 import java.util.ArrayList;
@@ -52,6 +54,8 @@ import java.util.Iterator;
  * SearchFilter.SearchFilterCollection to define search filter.
  */
 public abstract class SearchFilter extends ComplexProperty {
+
+  private static final Log LOG = LogFactory.getLog(SearchFilter.class);
 
   /**
    * Initializes a new instance of the SearchFilter class.
@@ -1113,9 +1117,9 @@ public abstract class SearchFilter extends ComplexProperty {
             reader.read();
             reader.ensureCurrentNodeIsStartElement();
           } catch (ServiceXmlDeserializationException e) {
-            e.printStackTrace();
+            LOG.error(e);
           } catch (XMLStreamException e) {
-            e.printStackTrace();
+            LOG.error(e);
           }
 
           if (reader.isStartElement(XmlNamespace.Types,

--- a/src/main/java/microsoft/exchange/webservices/data/security/SafeXmlDocument.java
+++ b/src/main/java/microsoft/exchange/webservices/data/security/SafeXmlDocument.java
@@ -24,6 +24,8 @@
 package microsoft.exchange.webservices.data.security;
 
 import microsoft.exchange.webservices.data.exception.NotSupportedException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.DOMImplementation;
 import org.w3c.dom.Document;
 import org.xml.sax.EntityResolver;
@@ -42,6 +44,8 @@ import java.io.*;
  * XmlDocument that does not allow DTD parsing.
  */
 public class SafeXmlDocument extends DocumentBuilder {
+
+  private static final Log LOG = LogFactory.getLog(SafeXmlDocument.class);
 
   /**
    * Initializes a new instance of the SafeXmlDocument class.
@@ -112,10 +116,10 @@ public class SafeXmlDocument extends DocumentBuilder {
         this.load((InputStream) reader);
       } catch (XMLStreamException e) {
         // TODO Auto-generated catch block
-        e.printStackTrace();
+        LOG.error(e);
       } catch (FileNotFoundException e) {
         // TODO Auto-generated catch block
-        e.printStackTrace();
+        LOG.error(e);
       }
     }
   }
@@ -136,7 +140,7 @@ public class SafeXmlDocument extends DocumentBuilder {
         this.load((InputStream) reader);
       } catch (XMLStreamException e) {
         // TODO Auto-generated catch block
-        e.printStackTrace();
+        LOG.error(e);
       }
     }
   }
@@ -167,7 +171,7 @@ public class SafeXmlDocument extends DocumentBuilder {
         this.load((InputStream) reader);
       } catch (XMLStreamException e) {
         // TODO Auto-generated catch block
-        e.printStackTrace();
+        LOG.error(e);
       }
     }
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,42 @@
+<configuration scan="true" debug="true">
+    <!--
+
+        The MIT License
+        Copyright (c) 2012 Microsoft Corporation
+
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:
+
+        The above copyright notice and this permission notice shall be included in
+        all copies or substantial portions of the Software.
+
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+        THE SOFTWARE.
+
+    -->
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- On Windows machines setting withJansi to true enables ANSI
+         color code interpretation by the Jansi library. This requires
+         org.fusesource.jansi:jansi:1.8 on the class path.  Note that
+         Unix-based operating systems such as Linux and Mac OS X
+         support ANSI color codes by default. -->
+        <withJansi>true</withJansi>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
logback and jansi are added for test purpose only
all System.out.print are replaced with regular LOG.debug statements
all e.printStackTrace() are replaced with regular LOG.error statements
Fixes #267 
This is the same PR as #275 , but this time, commons-logging is used as logging facade.

Of course, either this one or #275 can be merged, but not both.