### PR TITLE
Fix Javadoc

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AlternateMailboxCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AlternateMailboxCollection.java
@@ -73,6 +73,7 @@ public final class AlternateMailboxCollection {
 
   /**
    * Gets the collection of alternate mailboxes.
+   * @return alternate mailboxes
    */
   public List<AlternateMailbox> getEntries() {
     return this.entries;

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverDnsClient.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverDnsClient.java
@@ -75,8 +75,8 @@ class AutodiscoverDnsClient {
    *
    * @param domain the domain
    * @return Autodiscover hostname (will be null if lookup failed).
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws java.io.IOException                 Signals that an I/O exception has occurred.
+   * @throws XMLStreamException the XML stream exception
+   * @throws IOException signals that an I/O exception has occurred.
    */
   protected String findAutodiscoverHostFromSrv(String domain)
       throws XMLStreamException, IOException {
@@ -104,9 +104,9 @@ class AutodiscoverDnsClient {
    * Finds the best matching SRV record.
    *
    * @param domain the domain
-   * @return DnsSrvRecord(will be null if lookup failed).
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws java.io.IOException                 Signals that an I/O exception has occurred.
+   * @return DnsSrvRecord (will be null if lookup failed)
+   * @throws XMLStreamException the XML stream exception
+   * @throws IOException signals that an I/O exception has occurred.
    */
   private DnsSrvRecord findBestMatchingSrvRecord(String domain)
       throws XMLStreamException, IOException {

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
@@ -248,9 +248,8 @@ public class AutodiscoverService extends ExchangeServiceBase
       Class<TSettings> cls, String emailAddress, URI url)
       throws Exception {
     this
-        .traceMessage(TraceFlags.AutodiscoverConfiguration, String
-            .format("Trying to call Autodiscover for %s on %s.",
-                emailAddress, url));
+        .traceMessage(TraceFlags.AutodiscoverConfiguration,
+                      String.format("Trying to call Autodiscover for %s on %s.", emailAddress, url));
 
     TSettings settings = cls.newInstance();
 
@@ -358,14 +357,12 @@ public class AutodiscoverService extends ExchangeServiceBase
   private void writeLegacyAutodiscoverRequest(String emailAddress,
       ConfigurationSettingsBase settings, PrintWriter writer)
       throws IOException {
-    writer.write(String.format("<Autodiscover xmlns=\"%s\">",
-        AutodiscoverRequestNamespace));
+    writer.write(String.format("<Autodiscover xmlns=\"%s\">", AutodiscoverRequestNamespace));
     writer.write("<Request>");
     writer.write(String.format("<EMailAddress>%s</EMailAddress>",
         emailAddress));
-    writer.write(String.format(
-        "<AcceptableResponseSchema>%s</AcceptableResponseSchema>",
-        settings.getNamespace()));
+    writer.write(
+        String.format("<AcceptableResponseSchema>%s</AcceptableResponseSchema>", settings.getNamespace()));
     writer.write("</Request>");
     writer.write("</Autodiscover>");
   }
@@ -375,19 +372,19 @@ public class AutodiscoverService extends ExchangeServiceBase
    * standard non-SSL Autodiscover URL.
    *
    * @param domainName the domain name
-   * @return A valid SSL-enabled redirection URL. (May be null).
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException the eWS http exception
-   * @throws javax.xml.stream.XMLStreamException                  the xML stream exception
-   * @throws java.io.IOException                                  Signals that an I/O exception has occurred.
-   * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException                                the service local exception
-   * @throws java.net.URISyntaxException                          the uRI syntax exception
+   * @return A valid SSL-enabled redirection URL. (May be null)
+   * @throws EWSHttpException the eWS http exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws IOException Signals that an I/O exception has occurred.
+   * @throws ServiceLocalException the service local exception
+   * @throws URISyntaxException the uRI syntax exception
    */
   private URI getRedirectUrl(String domainName)
       throws EWSHttpException, XMLStreamException, IOException, ServiceLocalException, URISyntaxException {
     String url = String.format(AutodiscoverLegacyHttpUrl, "autodiscover." + domainName);
 
     traceMessage(TraceFlags.AutodiscoverConfiguration,
-        String.format("Trying to get Autodiscover redirection URL from %s.", url));
+                 String.format("Trying to get Autodiscover redirection URL from %s.", url));
 
     HttpWebRequest request = null;
 
@@ -439,11 +436,11 @@ public class AutodiscoverService extends ExchangeServiceBase
    * Tries the get redirection response.
    *
    * @param request     the request
-   * @param redirectUrl The redirect URL.
-   * @return True if a valid redirection URL was found.
-   * @throws javax.xml.stream.XMLStreamException                  the xML stream exception
-   * @throws java.io.IOException                                  Signals that an I/O exception has occurred.
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException the eWS http exception
+   * @param redirectUrl the redirect URL
+   * @return true if a valid redirection URL was found
+   * @throws XMLStreamException the XML stream exception
+   * @throws IOException signals that an I/O exception has occurred.
+   * @throws EWSHttpException the eWS http exception
    */
   private boolean tryGetRedirectionResponse(HttpWebRequest request,
       OutParam<URI> redirectUrl) throws XMLStreamException, IOException,
@@ -810,8 +807,7 @@ public class AutodiscoverService extends ExchangeServiceBase
     // to specify delegate to be called to determine whether we are allowed
     // to use the redirection URL.
     if (this
-        .callRedirectionUrlValidationCallback(
-            redirectionUrl.toString())) {
+        .callRedirectionUrlValidationCallback(redirectionUrl.toString())) {
       for (int currentHop = 0; currentHop < AutodiscoverService.AutodiscoverMaxRedirections; currentHop++) {
         try {
           settings.setParam(this.getLegacyUserSettingsAtUrl(cls,
@@ -950,17 +946,11 @@ public class AutodiscoverService extends ExchangeServiceBase
    * @param emailAddress      The email address to use.
    * @param requestedSettings The requested settings.
    * @return GetUserSettingsResponse
+   * @throws Exception on error
    */
   protected GetUserSettingsResponse internalGetLegacyUserSettings(
       String emailAddress,
       List<UserSettingName> requestedSettings) throws Exception {
-    // Cannot call legacy Autodiscover service with WindowsLive credential
-    	    	   	
-        /*if ((this.getCredentials() != null) && (this.getCredentials() instanceof WindowsLiveCredentials)) {
-            throw new AutodiscoverLocalException(
-					Strings.WLIDCredentialsCannotBeUsedWithLegacyAutodiscover);
-        }*/
-
     // Cannot call legacy Autodiscover service with WindowsLive and other WSSecurity-based credential
     if ((this.getCredentials() != null) && (this.getCredentials() instanceof WSSecurityBasedCredentials)) {
       throw new AutodiscoverLocalException(
@@ -983,6 +973,7 @@ public class AutodiscoverService extends ExchangeServiceBase
    * @param smtpAddress       SMTP address.
    * @param requestedSettings The requested settings.
    * @return GetUserSettingsResponse
+   * @throws Exception on error
    */
   protected GetUserSettingsResponse internalGetSoapUserSettings(
       String smtpAddress,
@@ -1624,9 +1615,9 @@ public class AutodiscoverService extends ExchangeServiceBase
    *
    * @param request      the request
    * @param memoryStream the memory stream
-   * @throws javax.xml.stream.XMLStreamException                  the xML stream exception
-   * @throws java.io.IOException                                  Signals that an I/O exception has occurred.
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException the eWS http exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws IOException signals that an I/O exception has occurred.
+   * @throws EWSHttpException the eWS http exception
    */
   public void traceResponse(HttpWebRequest request, ByteArrayOutputStream memoryStream) throws XMLStreamException,
       IOException, EWSHttpException {
@@ -1651,8 +1642,8 @@ public class AutodiscoverService extends ExchangeServiceBase
    * appropriate parameters, based on the configuration of this service
    * object.
    *
-   * @param url The URL that the HttpWebRequest should target.
-   * @return HttpWebRequest The HttpWebRequest.
+   * @param url The URL that the HttpWebRequest should target
+   * @return HttpWebRequest The HttpWebRequest
    * @throws ServiceLocalException       the service local exception
    * @throws java.net.URISyntaxException the uRI syntax exception
    */
@@ -1710,7 +1701,7 @@ public class AutodiscoverService extends ExchangeServiceBase
   /**
    * Initializes a new instance of the "AutodiscoverService" class.
    *
-   * @throws microsoft.exchange.webservices.data.exception.ArgumentException
+   * @throws ArgumentException on validation error
    */
   public AutodiscoverService() throws ArgumentException {
     this(ExchangeVersion.Exchange2010);
@@ -1719,8 +1710,8 @@ public class AutodiscoverService extends ExchangeServiceBase
   /**
    * Initializes a new instance of the "AutodiscoverService" class.
    *
-   * @param requestedServerVersion The requested server version.
-   * @throws microsoft.exchange.webservices.data.exception.ArgumentException
+   * @param requestedServerVersion The requested server version
+   * @throws ArgumentException on validation error
    */
   public AutodiscoverService(ExchangeVersion requestedServerVersion)
       throws ArgumentException {
@@ -1730,9 +1721,8 @@ public class AutodiscoverService extends ExchangeServiceBase
   /**
    * Initializes a new instance of the "AutodiscoverService" class.
    *
-   * @param domain The domain that will be used to determine the URL of the
-   *               service.
-   * @throws microsoft.exchange.webservices.data.exception.ArgumentException
+   * @param domain The domain that will be used to determine the URL of the service
+   * @throws ArgumentException on validation error
    */
   public AutodiscoverService(String domain) throws ArgumentException {
     this(null, domain);
@@ -1741,10 +1731,9 @@ public class AutodiscoverService extends ExchangeServiceBase
   /**
    * Initializes a new instance of the "AutodiscoverService" class.
    *
-   * @param domain                 The domain that will be used to determine the URL of the
-   *                               service.
-   * @param requestedServerVersion The requested server version.
-   * @throws microsoft.exchange.webservices.data.exception.ArgumentException
+   * @param domain                 The domain that will be used to determine the URL of the service
+   * @param requestedServerVersion The requested server version
+   * @throws ArgumentException on validation error
    */
   public AutodiscoverService(String domain,
       ExchangeVersion requestedServerVersion) throws ArgumentException {
@@ -1754,8 +1743,8 @@ public class AutodiscoverService extends ExchangeServiceBase
   /**
    * Initializes a new instance of the "AutodiscoverService" class.
    *
-   * @param url The URL of the service.
-   * @throws microsoft.exchange.webservices.data.exception.ArgumentException
+   * @param url The URL of the service
+   * @throws ArgumentException on validation error
    */
   public AutodiscoverService(URI url) throws ArgumentException {
     this(url, url.getHost());
@@ -1764,9 +1753,9 @@ public class AutodiscoverService extends ExchangeServiceBase
   /**
    * Initializes a new instance of the "AutodiscoverService" class.
    *
-   * @param url                    The URL of the service.
-   * @param requestedServerVersion The requested server version.
-   * @throws microsoft.exchange.webservices.data.exception.ArgumentException
+   * @param url                    The URL of the service
+   * @param requestedServerVersion The requested server version
+   * @throws ArgumentException on validation error
    */
   public AutodiscoverService(URI url,
       ExchangeVersion requestedServerVersion) throws ArgumentException {
@@ -1776,10 +1765,9 @@ public class AutodiscoverService extends ExchangeServiceBase
   /**
    * Initializes a new instance of the "AutodiscoverService" class.
    *
-   * @param url    The URL of the service.
-   * @param domain The domain that will be used to determine the URL of the
-   *               service.
-   * @throws microsoft.exchange.webservices.data.exception.ArgumentException
+   * @param url    The URL of the service
+   * @param domain The domain that will be used to determine the URL of the service
+   * @throws ArgumentException on validation error
    */
   public AutodiscoverService(URI url, String domain)
       throws ArgumentException {
@@ -1797,7 +1785,7 @@ public class AutodiscoverService extends ExchangeServiceBase
    * @param domain                 The domain that will be used to determine the URL of the
    *                               service.
    * @param requestedServerVersion The requested server version.
-   * @throws microsoft.exchange.webservices.data.exception.ArgumentException
+   * @throws ArgumentException on validation error
    */
   public AutodiscoverService(URI url, String domain,
       ExchangeVersion requestedServerVersion) throws ArgumentException {
@@ -1832,15 +1820,14 @@ public class AutodiscoverService extends ExchangeServiceBase
 
   /**
    * Retrieves the specified settings for single SMTP address.
-   *
+   * <p>This method will run the entire Autodiscover "discovery"
+   * algorithm and will follow address and URL redirections.</p>
+
    * @param userSmtpAddress  The SMTP addresses of the user.
    * @param userSettingNames The user setting names.
    * @return A UserResponse object containing the requested settings for the
    * specified user.
-   * @throws Exception the exception
-   *                   <p/>
-   *                   This method handles will run the entire Autodiscover "discovery"
-   *                   algorithm and will follow address and URL redirections.
+   * @throws Exception on error
    */
   public GetUserSettingsResponse getUserSettings(String userSmtpAddress,
       UserSettingName... userSettingNames) throws Exception {
@@ -1936,100 +1923,8 @@ public class AutodiscoverService extends ExchangeServiceBase
   }
 
   /**
-   * Try to get the partner access information for the given target tenant.
-   *
-   * @param targetTenantDomain The target domain or user email address.
-   * @param partnerAccessCredentials The partner access credential.
-   * @param targetTenantAutodiscoverUrl The autodiscover url for the given tenant.
-   * @return True if the partner access information was retrieved, false otherwise.
-   */
-
-  /** commented as the code belongs to Partener Token credential. */
-	  
-  /*  public boolean tryGetPartnerAccess(
-        String targetTenantDomain,
-        OutParam<ExchangeCredentials> partnerAccessCredentials,
-        OutParam<URI> targetTenantAutodiscoverUrl)
-    {
-        EwsUtilities.validateNonBlankStringParam(targetTenantDomain, "targetTenantDomain");
-
-        // the user should set the url to its own tenant's autodiscover url.
-        // 
-        if (this.url == null)
-        {
-            throw new ServiceValidationException(Strings.PartnerTokenRequestRequiresUrl);
-        }
-
-        if (this.getRequestedServerVersion().ordinal() < ExchangeVersion.Exchange2010_SP1.ordinal())
-        {
-            throw new ServiceVersionException(
-                String.format(
-                    Strings.PartnerTokenIncompatibleWithRequestVersion,
-                    ExchangeVersion.Exchange2010_SP1));
-        }
-
-        partnerAccessCredentials = null;
-        targetTenantAutodiscoverUrl = null;
-
-        String smtpAddress = targetTenantDomain;
-        if (!smtpAddress.contains("@"))
-        {
-            smtpAddress = "SystemMailbox{e0dc1c29-89c3-4034-b678-e6c29d823ed9}@" + targetTenantDomain;
-        }
-
-        List<String> smtpAddresses = new ArrayList<String>();
-        smtpAddresses.add(smtpAddress);
-        List<UserSettingName> settings = new ArrayList<UserSettingName>();
-        settings.add(UserSettingName.ExternalEwsUrl);
-        
-        GetUserSettingsRequest request = new GetUserSettingsRequest(this, this.url, true  expectPartnerToken );
-        request.setSmtpAddresses(smtpAddresses);
-        request.setSettings(settings);
-        GetUserSettingsResponseCollection response = request.execute();
-
-        if (request.getPartnerToken()!=null && !request.getPartnerToken().isEmpty())
-            || request.getPartnerTokenReference()!=null && !request.getPartnerTokenReference().isEmpty() ))
-        {
-            return false;
-        }
-
-        if (request.getErrorCode() == AutodiscoverErrorCode.NoError)
-        {
-            GetUserSettingsResponse firstResponse = request.getResponse(0);
-            if (firstResponse.getErrorCode() == AutodiscoverErrorCode.NoError)
-            {
-                targetTenantAutodiscoverUrl = this.url;
-            }
-            else if (firstResponse.getErrorCode() == AutodiscoverErrorCode.RedirectUrl)
-            {
-                targetTenantAutodiscoverUrl = new URI(firstResponse.getRedirectTarget());
-            }
-            else
-            {
-                return false;
-            }
-        }
-        else
-        {
-            return false;
-        }
-
-        partnerAccessCredentials = new PartnerTokenCredentials(
-            request.getPartnerToken(),
-            request.getPartnerTokenReference());
-
-        targetTenantAutodiscoverUrl = partnerAccessCredentials.adjustUrl(
-            targetTenantAutodiscoverUrl);
-
-        return true;
-    }
-*/
-
-  /**
    * Gets the domain this service is bound to. When this property is
-   * set, the domain
-   * <p/>
-   * name is used to automatically determine the Autodiscover service URL.
+   * set, the domain name is used to automatically determine the Autodiscover service URL.
    *
    * @return the domain
    */
@@ -2043,7 +1938,7 @@ public class AutodiscoverService extends ExchangeServiceBase
    * name is used to automatically determine the Autodiscover service URL.
    *
    * @param value the new domain
-   * @throws microsoft.exchange.webservices.data.exception.ArgumentException
+   * @throws ArgumentException on validation error
    */
   public void setDomain(String value) throws ArgumentException {
     EwsUtilities.validateDomainNameAllowNull(value, "Domain");

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/IFunctionDelegate.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/IFunctionDelegate.java
@@ -38,7 +38,6 @@ import java.util.List;
  *
  * @param <T1>      the generic type
  * @param <T2>      the generic type
- * @param <T3>      the generic type
  * @param <TResult> the generic type
  */
 public interface IFunctionDelegate<T1 extends List<?>, T2 extends List<?>, TResult> {
@@ -49,14 +48,10 @@ public interface IFunctionDelegate<T1 extends List<?>, T2 extends List<?>, TResu
    * @param arg1 the arg1
    * @param arg2 the arg2
    * @param arg3 the arg3
+   * @param arg4 the arg4
    * @return the t result
-   * @throws AutodiscoverLocalException          the autodiscover local exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws java.io.IOException                 Signals that an I/O exception has occurred.
-   * @throws ServiceLocalException               the service local exception
-   * @throws Exception                           the exception
+   * @throws Exception the exception
    */
-  TResult func(T1 arg1, T2 arg2, ExchangeVersion arg3, URI arg4)
-      throws AutodiscoverLocalException, XMLStreamException, IOException, ServiceLocalException, Exception;
+  TResult func(T1 arg1, T2 arg2, ExchangeVersion arg3, URI arg4) throws Exception;
 
 }

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/ProtocolConnection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/ProtocolConnection.java
@@ -50,7 +50,7 @@ public final class ProtocolConnection {
   private int port;
 
   /**
-   * Initializes a new instance of the <see cref="ProtocolConnection"/> class.
+   * Initializes a new instance of the {@link ProtocolConnection} class.
    */
 
   protected ProtocolConnection() {

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/WebClientUrlCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/WebClientUrlCollection.java
@@ -41,8 +41,7 @@ public final class WebClientUrlCollection {
   private ArrayList<WebClientUrl> urls;
 
   /**
-   * Initializes a new instance of the <see cref="WebClientUrlCollection"/>
-   * class.
+   * Initializes a new instance of the {@link WebClientUrlCollection} class.
    */
   public WebClientUrlCollection() {
     this.urls = new ArrayList<WebClientUrl>();

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/configuration/outlook/OutlookConfigurationSettings.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/configuration/outlook/OutlookConfigurationSettings.java
@@ -34,9 +34,6 @@ import microsoft.exchange.webservices.data.core.ILazyMember;
 import microsoft.exchange.webservices.data.core.LazyMember;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.enumeration.UserSettingName;
-import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
-
-import javax.xml.stream.XMLStreamException;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -120,16 +117,12 @@ public final class OutlookConfigurationSettings extends ConfigurationSettingsBas
   /**
    * Tries to read the current XML element.
    *
-   * @param reader The reader.
-   * @return True is the current element was read, false otherwise.
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws Exception                           the exception
+   * @param reader the reader
+   * @return true is the current element was read, false otherwise
+   * @throws Exception the exception
    */
   @Override
-  public boolean tryReadCurrentXmlElement(EwsXmlReader reader)
-      throws ServiceXmlDeserializationException, XMLStreamException,
-      Exception {
+  public boolean tryReadCurrentXmlElement(EwsXmlReader reader) throws Exception {
     if (!super.tryReadCurrentXmlElement(reader)) {
       if (reader.getLocalName().equals(XmlElementNames.User)) {
         this.user.loadFromXml(reader);

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/exception/AutodiscoverRemoteException.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/exception/AutodiscoverRemoteException.java
@@ -77,7 +77,7 @@ public class AutodiscoverRemoteException extends ServiceRemoteException {
   }
 
   /**
-   * Gets the error. <value>The error.</value>
+   * Gets the error.
    *
    * @return the error
    */

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/exception/error/DomainSettingError.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/exception/error/DomainSettingError.java
@@ -50,9 +50,8 @@ public final class DomainSettingError {
   private String settingName;
 
   /**
-   * Initializes a new instance of the <see cref="DomainSettingError"/> class.
+   * Initializes a new instance of the {@link DomainSettingError} class.
    */
-
   public DomainSettingError() {
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/request/ApplyConversationActionRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/request/ApplyConversationActionRequest.java
@@ -52,9 +52,9 @@ public final class ApplyConversationActionRequest extends MultiResponseServiceRe
   /**
    * Initializes a new instance of the ApplyConversationActionRequest class
    *
-   * @param service           The service.
-   * @param errorHandlingMode Indicates how errors should be handled.
-   * @throws Exception
+   * @param service           The service
+   * @param errorHandlingMode Indicates how errors should be handled
+   * @throws Exception on error
    */
   public ApplyConversationActionRequest(ExchangeService service, ServiceErrorHandling errorHandlingMode) throws Exception {
     super(service, errorHandlingMode);
@@ -86,13 +86,15 @@ public final class ApplyConversationActionRequest extends MultiResponseServiceRe
   /**
    * Validate request.
    *
-   * @throws Exception
+   * @throws Exception on validation error
    */
   @Override
   protected void validate() throws Exception {
     super.validate();
-    EwsUtilities.validateParamCollection(this.
-                                             conversationActions.iterator(), "conversationActions");
+    EwsUtilities.validateParamCollection(
+      conversationActions.iterator(), "conversationActions"
+    );
+
     for (int iAction = 0; iAction < this.getConversationActions().size(); iAction++) {
       this.getConversationActions().get(iAction).validate();
     }
@@ -103,11 +105,10 @@ public final class ApplyConversationActionRequest extends MultiResponseServiceRe
    * Writes XML elements.
    *
    * @param writer The writer.
-   * @throws Exception
+   * @throws Exception on validation error
    */
   @Override
-  protected void writeElementsToXml(EwsServiceXmlWriter writer)
-      throws Exception {
+  protected void writeElementsToXml(EwsServiceXmlWriter writer) throws Exception {
     writer.writeStartElement(
         XmlNamespace.Messages,
         XmlElementNames.ConversationActions);

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/request/AutodiscoverRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/request/AutodiscoverRequest.java
@@ -58,7 +58,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.text.ParseException;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -108,10 +107,9 @@ public abstract class AutodiscoverRequest {
   /**
    * Validates the request.
    *
-   * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
-   * @throws Exception             the exception
+   * @throws Exception the exception
    */
-  protected void validate() throws ServiceLocalException, Exception {
+  protected void validate() throws Exception {
     this.getService().validate();
   }
 
@@ -119,11 +117,9 @@ public abstract class AutodiscoverRequest {
    * Executes this instance.
    *
    * @return the autodiscover response
-   * @throws ServiceLocalException the service local exception
-   * @throws Exception             the exception
+   * @throws Exception the exception
    */
-  protected AutodiscoverResponse internalExecute()
-      throws ServiceLocalException, Exception {
+  protected AutodiscoverResponse internalExecute() throws Exception {
     this.validate();
     HttpWebRequest request = null;
     try {
@@ -172,16 +168,6 @@ public abstract class AutodiscoverRequest {
           throw new ServiceRemoteException("The service returned an invalid redirection response.");
         }
       }
-
-			/*
-                         * BufferedReader in = new BufferedReader(new
-			 * InputStreamReader(request.getInputStream()));
-			 * 
-			 * String decodedString;
-			 * 
-			 * while ((decodedString = in.readLine()) != null) {
-			 * LOG.debug(decodedString); } in.close();
-			 */
 
       memoryStream = new ByteArrayOutputStream();
       InputStream serviceResponseStream = request.getInputStream();
@@ -335,11 +321,11 @@ public abstract class AutodiscoverRequest {
   /**
    * Create a redirection response.
    *
-   * @param httpWebResponse The HTTP web response.
-   * @return AutodiscoverResponse autodiscoverResponse object.
-   * @throws javax.xml.stream.XMLStreamException                  the xML stream exception
-   * @throws java.io.IOException                                  Signals that an I/O exception has occurred.
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException the eWS http exception
+   * @param httpWebResponse the HTTP web response
+   * @return AutodiscoverResponse autodiscoverResponse object
+   * @throws XMLStreamException the XML stream exception
+   * @throws IOException signals that an I/O exception has occurred
+   * @throws EWSHttpException the eWS http exception
    */
   private AutodiscoverResponse createRedirectionResponse(
       HttpWebRequest httpWebResponse) throws XMLStreamException,
@@ -467,9 +453,10 @@ public abstract class AutodiscoverRequest {
   /**
    * Writes the autodiscover SOAP request.
    *
-   * @param requestUrl Request URL.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @param requestUrl request URL
+   * @param writer writer object
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   protected void writeSoapRequest(URI requestUrl,
       EwsServiceXmlWriter writer) throws XMLStreamException, ServiceXmlSerializationException {
@@ -538,9 +525,9 @@ public abstract class AutodiscoverRequest {
   /**
    * Write extra headers.
    *
-   * @param writer The writer
-   * @throws ServiceXmlSerializationException
-   * @throws javax.xml.stream.XMLStreamException
+   * @param writer the writer
+   * @throws ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   protected void writeExtraCustomSoapHeadersToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {
@@ -552,17 +539,14 @@ public abstract class AutodiscoverRequest {
   /**
    * Writes XML body.
    *
-   * @param writer The writer.
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @param writer the writer
+   * @throws ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   protected void writeBodyToXml(EwsServiceXmlWriter writer)
       throws ServiceXmlSerializationException, XMLStreamException {
     writer.writeStartElement(XmlNamespace.Autodiscover, this
         .getRequestXmlElementName());
-    // writer.WriteAttributeValue("xmlns",
-    // EwsUtilities.AutodiscoverSoapNamespacePrefix,
-    // EwsUtilities.AutodiscoverSoapNamespace);
 
     this.writeAttributesToXml(writer);
     this.writeElementsToXml(writer);
@@ -576,8 +560,8 @@ public abstract class AutodiscoverRequest {
    *
    * @param request the request
    * @return ResponseStream
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException the eWS http exception
-   * @throws java.io.IOException                                  Signals that an I/O exception has occurred.
+   * @throws EWSHttpException the eWS http exception
+   * @throws IOException signals that an I/O exception has occurred.
    */
   protected static InputStream getResponseStream(HttpWebRequest request)
       throws EWSHttpException, IOException {
@@ -620,7 +604,7 @@ public abstract class AutodiscoverRequest {
    * Reads a single SOAP header.
    *
    * @param reader EwsXmlReader
-   * @throws Exception
+   * @throws Exception on error
    */
   protected void readSoapHeader(EwsXmlReader reader) throws Exception {
     // Is this the ServerVersionInfo?
@@ -675,14 +659,9 @@ public abstract class AutodiscoverRequest {
    *
    * @param reader EwsXmlReader.
    * @return AutodiscoverResponse AutodiscoverResponse object
-   * @throws InstantiationException   the instantiation exception
-   * @throws IllegalAccessException   the illegal access exception
-   * @throws java.text.ParseException the parse exception
-   * @throws Exception                the exception
+   * @throws Exception the exception
    */
-  protected AutodiscoverResponse readSoapBody(EwsXmlReader reader)
-      throws InstantiationException, IllegalAccessException,
-      ParseException, Exception {
+  protected AutodiscoverResponse readSoapBody(EwsXmlReader reader) throws Exception {
     reader.readStartElement(XmlNamespace.Soap,
         XmlElementNames.SOAPBodyElementName);
     AutodiscoverResponse responses = this.loadFromXml(reader);
@@ -695,15 +674,10 @@ public abstract class AutodiscoverRequest {
    * Loads response from XML.
    *
    * @param reader The reader.
-   * @return AutodiscoverResponse AutodiscoverResponse object
-   * @throws InstantiationException   the instantiation exception
-   * @throws IllegalAccessException   the illegal access exception
-   * @throws java.text.ParseException the parse exception
-   * @throws Exception                the exception
+   * @return AutodiscoverResponse object
+   * @throws Exception the exception
    */
-  protected AutodiscoverResponse loadFromXml(EwsXmlReader reader)
-      throws InstantiationException, IllegalAccessException,
-      ParseException, Exception {
+  protected AutodiscoverResponse loadFromXml(EwsXmlReader reader) throws Exception {
     String elementName = this.getResponseXmlElementName();
     reader.readStartElement(XmlNamespace.Autodiscover, elementName);
     AutodiscoverResponse response = this.createServiceResponse();
@@ -751,9 +725,9 @@ public abstract class AutodiscoverRequest {
   /**
    * Writes elements to request XML.
    *
-   * @param writer The writer.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   protected abstract void writeElementsToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException;

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/request/GetDomainSettingsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/request/GetDomainSettingsRequest.java
@@ -67,8 +67,7 @@ public class GetDomainSettingsRequest extends AutodiscoverRequest {
   private ExchangeVersion requestedVersion;
 
   /**
-   * Initializes a new instance of the <see cref="GetDomainSettingsRequest"/>
-   * class.
+   * Initializes a new instance of the {@link GetDomainSettingsRequest} class.
    *
    * @param service the service
    * @param url     the url
@@ -108,11 +107,9 @@ public class GetDomainSettingsRequest extends AutodiscoverRequest {
    * Executes this instance.
    *
    * @return the gets the domain settings response collection
-   * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
-   * @throws Exception                                                 the exception
+   * @throws Exception the exception
    */
-  public GetDomainSettingsResponseCollection execute()
-      throws ServiceLocalException, Exception {
+  public GetDomainSettingsResponseCollection execute() throws Exception {
     GetDomainSettingsResponseCollection responses =
         (GetDomainSettingsResponseCollection) this
             .internalExecute();
@@ -181,7 +178,7 @@ public class GetDomainSettingsRequest extends AutodiscoverRequest {
    * Writes the attribute to XML.
    *
    * @param writer The writer.
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException the service xml serialization exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected void writeAttributesToXml(EwsServiceXmlWriter writer)
@@ -194,9 +191,9 @@ public class GetDomainSettingsRequest extends AutodiscoverRequest {
   /**
    * Writes request to XML.
    *
-   * @param writer The writer.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/request/GetUserSettingsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/request/GetUserSettingsRequest.java
@@ -34,7 +34,6 @@ import microsoft.exchange.webservices.data.core.ExchangeServiceBase;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.enumeration.UserSettingName;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
-import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.ServiceValidationException;
 import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
 
@@ -51,10 +50,10 @@ public class GetUserSettingsRequest extends AutodiscoverRequest {
   /**
    * Action Uri of Autodiscover.GetUserSettings method.
    */
-  // / </summary>
   private static final String GetUserSettingsActionUri = EwsUtilities.
       AutodiscoverSoapNamespace +
       "/Autodiscover/GetUserSettings";
+
   private List<String> smtpAddresses;
   private List<UserSettingName> settings;
 
@@ -66,29 +65,26 @@ public class GetUserSettingsRequest extends AutodiscoverRequest {
   private String partnerToken;
 
   /**
-   * Initializes a new instance of the <see cref="GetUserSettingsRequest"/>
-   * class.
+   * Initializes a new instance of the {@link GetUserSettingsRequest} class.
    *
    * @param service the service
    * @param url     the url
-   * @throws microsoft.exchange.webservices.data.exception.ServiceValidationException
+   * @throws ServiceValidationException on validation error
    */
   public GetUserSettingsRequest(AutodiscoverService service, URI url) throws ServiceValidationException {
     this(service, url, false);
   }
 
   /**
-   * Initializes a new instance of the <see cref="GetUserSettingsRequest"/>
-   * class.
+   * Initializes a new instance of the {@link GetUserSettingsRequest} class.
    *
-   * @param service Autodiscover service associated with this request
-   * @param url     URL of Autodiscover service.
-   * @throws ServiceValidationException
+   * @param service autodiscover service associated with this request
+   * @param url URL of Autodiscover service
+   * @param expectPartnerToken expect partner token or not
+   * @throws ServiceValidationException on validation error
    */
   public GetUserSettingsRequest(AutodiscoverService service, URI url, boolean expectPartnerToken)
-      throws ServiceValidationException
-
-  {
+      throws ServiceValidationException {
     super(service, url);
     this.expectPartnerToken = expectPartnerToken;
 
@@ -129,11 +125,9 @@ public class GetUserSettingsRequest extends AutodiscoverRequest {
    * Executes this instance.
    *
    * @return the gets the user settings response collection
-   * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
-   * @throws Exception                                                 the exception
+   * @throws Exception the exception
    */
-  public GetUserSettingsResponseCollection execute()
-      throws ServiceLocalException, Exception {
+  public GetUserSettingsResponseCollection execute() throws Exception {
     GetUserSettingsResponseCollection responses =
         (GetUserSettingsResponseCollection) this
             .internalExecute();
@@ -202,7 +196,7 @@ public class GetUserSettingsRequest extends AutodiscoverRequest {
    * Writes the attribute to XML.
    *
    * @param writer The writer.
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException the service xml serialization exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected void writeAttributesToXml(EwsServiceXmlWriter writer)
@@ -213,8 +207,9 @@ public class GetUserSettingsRequest extends AutodiscoverRequest {
   }
 
   /**
-   * @throws XMLStreamException
-   * @throws ServiceXmlSerializationException
+   * @param writer XML writer
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override public void writeExtraCustomSoapHeadersToXml(EwsServiceXmlWriter writer) throws XMLStreamException,
       ServiceXmlSerializationException {
@@ -230,9 +225,9 @@ public class GetUserSettingsRequest extends AutodiscoverRequest {
   /**
    * Writes request to XML.
    *
-   * @param writer The writer.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected void writeElementsToXml(EwsServiceXmlWriter writer)
@@ -270,8 +265,8 @@ public class GetUserSettingsRequest extends AutodiscoverRequest {
   /**
    * Read the partner token soap header.
    *
-   * @param reader ewsxmlreader
-   * @throws Exception
+   * @param reader eWS XML reader
+   * @throws Exception on error
    */
   @Override
   protected void readSoapHeader(EwsXmlReader reader) throws Exception {
@@ -292,8 +287,7 @@ public class GetUserSettingsRequest extends AutodiscoverRequest {
 
   /**
    * Gets the SMTP addresses.
-   *
-   * @return the smtp addresses
+   * @return the SMTP addresses
    */
   protected List<String> getSmtpAddresses() {
     return smtpAddresses;
@@ -301,7 +295,6 @@ public class GetUserSettingsRequest extends AutodiscoverRequest {
 
   /**
    * Sets the smtp addresses.
-   *
    * @param value the new smtp addresses
    */
   public void setSmtpAddresses(List<String> value) {
@@ -310,7 +303,6 @@ public class GetUserSettingsRequest extends AutodiscoverRequest {
 
   /**
    * Gets the settings.
-   *
    * @return the settings
    */
   protected List<UserSettingName> getSettings() {
@@ -329,6 +321,7 @@ public class GetUserSettingsRequest extends AutodiscoverRequest {
 
   /**
    * Gets the partner token.
+   * @return partner token
    */
   protected String getPartnerToken() {
     return partnerToken;
@@ -339,8 +332,8 @@ public class GetUserSettingsRequest extends AutodiscoverRequest {
   }
 
   /**
-   * <summary>
    * Gets the partner token reference.
+   * @return partner token reference
    */
   protected String getPartnerTokenReference() {
     return partnerTokenReference;

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/response/GetDomainSettingsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/response/GetDomainSettingsResponse.java
@@ -67,8 +67,7 @@ public final class GetDomainSettingsResponse extends AutodiscoverResponse {
   private Collection<DomainSettingError> domainSettingErrors;
 
   /**
-   * Initializes a new instance of the <see cref="GetDomainSettingsResponse"/>
-   * class.
+   * Initializes a new instance of the {@link GetDomainSettingsResponse} class.
    */
   public GetDomainSettingsResponse() {
     super();

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/response/GetUserSettingsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/response/GetUserSettingsResponse.java
@@ -67,8 +67,7 @@ public final class GetUserSettingsResponse extends AutodiscoverResponse {
   private Collection<UserSettingError> userSettingErrors;
 
   /**
-   * Initializes a new instance of the <see cref="GetUserSettingsResponse"/>
-   * class.
+   * Initializes a new instance of the {@link GetUserSettingsResponse} class.
    */
   public GetUserSettingsResponse() {
     super();
@@ -127,6 +126,7 @@ public final class GetUserSettingsResponse extends AutodiscoverResponse {
 
   /**
    * Sets the redirectionTarget (URL or email address).
+   * @param value redirect target value
    */
   public void setRedirectTarget(String value) {
     this.redirectTarget = value;
@@ -142,7 +142,8 @@ public final class GetUserSettingsResponse extends AutodiscoverResponse {
   }
 
   /**
-   * sets the requested settings for the user.
+   * Sets the requested settings for the user.
+   * @param settings settings map
    */
   public void setSettings(Map<UserSettingName, Object> settings) {
     this.settings = settings;
@@ -158,7 +159,8 @@ public final class GetUserSettingsResponse extends AutodiscoverResponse {
   }
 
   /**
-   * sets the requested settings for the user.
+   * Sets the requested settings for the user.
+   * @param value user setting errors
    */
   protected void setUserSettingErrors(Collection<UserSettingError> value) {
     this.userSettingErrors = value;

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsSSLProtocolSocketFactory.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsSSLProtocolSocketFactory.java
@@ -44,8 +44,6 @@ import java.security.GeneralSecurityException;
  * you are perfectly aware of security implications of accepting
  * self-signed certificates
  * </p>
- * <p/>
- * <p>
  * Example of using custom protocol socket factory for a specific host:
  * <pre>
  *     Protocol easyhttps = new Protocol("https", new EasySSLProtocolSocketFactory(), 443);
@@ -112,7 +110,7 @@ public class EwsSSLProtocolSocketFactory extends SSLConnectionSocketFactory {
    *
    * @param trustManager trust manager
    * @return socket factory for SSL protocol
-   * @throws GeneralSecurityException
+   * @throws GeneralSecurityException on security error
    */
   public static EwsSSLProtocolSocketFactory build(TrustManager trustManager)
     throws GeneralSecurityException {
@@ -125,7 +123,7 @@ public class EwsSSLProtocolSocketFactory extends SSLConnectionSocketFactory {
    * @param trustManager trust manager
    * @param hostnameVerifier hostname verifier
    * @return socket factory for SSL protocol
-   * @throws GeneralSecurityException
+   * @throws GeneralSecurityException on security error
    */
   public static EwsSSLProtocolSocketFactory build(
     TrustManager trustManager, HostnameVerifier hostnameVerifier

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceMultiResponseXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceMultiResponseXmlReader.java
@@ -34,13 +34,14 @@ import java.io.InputStreamReader;
 /**
  * Represents an xml reader used by the ExchangeService to parse multi-response streams,
  * such as GetStreamingEvents.
- * <p/>
+ * <p>
  * Necessary because the basic EwsServiceXmlReader does not
  * use normalization (see E14:60369), and in order to turn normalization off, it is
  * necessary to use an XmlTextReader, which does not allow the ConformanceLevel.Auto that
  * a multi-response stream requires.
  * If ever there comes a time we need to deal with multi-response streams with user-generated
  * content, we will need to tackle that parsing problem separately.
+ * </p>
  */
 public class EwsServiceMultiResponseXmlReader extends EwsServiceXmlReader {
 
@@ -60,24 +61,21 @@ public class EwsServiceMultiResponseXmlReader extends EwsServiceXmlReader {
   /**
    * Creates a new instance of the EwsServiceMultiResponseXmlReader class.
    *
-   * @param stream  The stream.
-   * @param service The service.
-   * @return an instance of EwsServiceMultiResponseXmlReader
-   * wrapped around the input stream.
-   * @throws Exception
+   * @param stream the stream
+   * @param service the service
+   * @return an instance of EwsServiceMultiResponseXmlReader wrapped around the input stream
+   * @throws Exception on error
    */
   public static EwsServiceMultiResponseXmlReader create(InputStream stream, ExchangeService service) throws Exception {
-    EwsServiceMultiResponseXmlReader reader =
-        new EwsServiceMultiResponseXmlReader(stream, service);
-    return reader;
+    return new EwsServiceMultiResponseXmlReader(stream, service);
   }
 
   /**
    * Creates the XML reader.
    *
-   * @param stream The stream.
-   * @return An XML reader to use.
-   * @throws javax.xml.stream.XMLStreamException
+   * @param stream The stream
+   * @return an XML reader to use
+   * @throws XMLStreamException the XML stream exception
    */
   private static XMLEventReader createXmlReader(InputStream stream)
       throws XMLStreamException {
@@ -96,9 +94,8 @@ public class EwsServiceMultiResponseXmlReader extends EwsServiceXmlReader {
   /**
    * Initializes the XML reader.
    *
-   * @param stream The stream.
-   *               An XML reader to use.
-   * @throws Exception
+   * @param stream The stream. An XML reader to use.
+   * @throws Exception on error
    */
   @Override
   protected XMLEventReader initializeXmlReader(InputStream stream)

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceXmlReader.java
@@ -50,9 +50,9 @@ public class EwsServiceXmlReader extends EwsXmlReader {
   /**
    * Initializes a new instance of the EwsXmlReader class.
    *
-   * @param stream  the stream
+   * @param stream the stream
    * @param service the service
-   * @throws Exception
+   * @throws Exception on error
    */
   public EwsServiceXmlReader(InputStream stream, ExchangeService service)
       throws Exception {
@@ -73,8 +73,8 @@ public class EwsServiceXmlReader extends EwsXmlReader {
   /**
    * Reads the element value as unspecified date.
    *
-   * @return Element value
-   * @throws Exception
+   * @return element value
+   * @throws Exception on error
    */
   public Date readElementValueAsUnspecifiedDate() throws Exception {
     return DateTimeUtils.convertDateStringToDate(readElementValue());
@@ -91,43 +91,18 @@ public class EwsServiceXmlReader extends EwsXmlReader {
       throws Exception {
     // Convert the element's value to a DateTime with no adjustment.
     String date = this.readElementValue();
-    Date tempDate = null;
 
     try {
       DateFormat formatter =
           new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
       formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-      tempDate = formatter.parse(date);
+      return formatter.parse(date);
     } catch (Exception e) {
-      //LOG.error(e);
       DateFormat formatter = new SimpleDateFormat(
           "yyyy-MM-dd'T'HH:mm:ss.SSS");
       formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
-      tempDate = formatter.parse(date);
+      return formatter.parse(date);
     }
-
-		/*
-                 * TimeZone tz = sdfin.getTimeZone(); Calendar calen =
-		 * Calendar.getInstance(); calen.setTime(tempDate);
-		 */
-
-    // Set the kind according to the service's time zone
-    // Since the TimeZone is default UTC so no need to checks for Local and
-    // other
-    // if ((this.service.getTimeZone()).equals(TimeZone.getTimeZone("utc")))
-    // {
-
-		/*
-                 * calen.setTimeInMillis(calen.getTimeInMillis() -
-		 * tz.getOffset(tempDate.getTime()));
-		 */
-    return tempDate;
-                /*
-		 * } else if (EwsUtilities.isLocalTimeZone(this.service.getTimeZone()))
-		 * { calen.setTimeInMillis(calen.getTimeInMillis() +
-		 * tz.getOffset(tempDate.getTime())); return calen.getTime(); } else {
-		 * return tempDate; }
-		 */
   }
 
   /**
@@ -163,7 +138,7 @@ public class EwsServiceXmlReader extends EwsXmlReader {
       boolean summaryPropertiesOnly) throws Exception {
 
     List<TServiceObject> serviceObjects = new ArrayList<TServiceObject>();
-    TServiceObject serviceObject = null;
+    TServiceObject serviceObject;
 
     this.readStartElement(XmlNamespace.Messages, collectionXmlElementName);
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceXmlWriter.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceXmlWriter.java
@@ -92,9 +92,9 @@ public class EwsServiceXmlWriter implements IDisposable {
   /**
    * Initializes a new instance.
    *
-   * @param service The service.
-   * @param stream  The stream.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @param service the service
+   * @param stream the stream
+   * @throws XMLStreamException the XML stream exception
    */
   public EwsServiceXmlWriter(ExchangeServiceBase service, OutputStream stream) throws XMLStreamException {
     this.service = service;
@@ -161,7 +161,7 @@ public class EwsServiceXmlWriter implements IDisposable {
   /**
    * Flushes this instance.
    *
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws XMLStreamException the XML stream exception
    */
   public void flush() throws XMLStreamException {
     this.xmlWriter.flush();
@@ -170,9 +170,9 @@ public class EwsServiceXmlWriter implements IDisposable {
   /**
    * Writes the start element.
    *
-   * @param xmlNamespace The XML namespace.
-   * @param localName    The local name of the element.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @param xmlNamespace the XML namespace
+   * @param localName    the local name of the element
+   * @throws XMLStreamException the XML stream exception
    */
   public void writeStartElement(XmlNamespace xmlNamespace, String localName)
       throws XMLStreamException {
@@ -184,7 +184,7 @@ public class EwsServiceXmlWriter implements IDisposable {
   /**
    * Writes the end element.
    *
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws XMLStreamException the XML stream exception
    */
   public void writeEndElement() throws XMLStreamException {
     this.xmlWriter.writeEndElement();
@@ -193,8 +193,8 @@ public class EwsServiceXmlWriter implements IDisposable {
   /**
    * Writes the attribute value.
    *
-   * @param localName The local name of the attribute.
-   * @param value     The value.
+   * @param localName the local name of the attribute
+   * @param value     the value
    * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeAttributeValue(String localName, Object value)
@@ -206,10 +206,10 @@ public class EwsServiceXmlWriter implements IDisposable {
   /**
    * Writes the attribute value.  Optionally emits empty string values.
    *
-   * @param localName              The local name of the attribute.
-   * @param alwaysWriteEmptyString Always emit the empty string as the value.
-   * @param value                  The value.
-   * @throws ServiceXmlSerializationException
+   * @param localName              the local name of the attribute.
+   * @param alwaysWriteEmptyString always emit the empty string as the value.
+   * @param value                  the value
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeAttributeValue(String localName,
       boolean alwaysWriteEmptyString,
@@ -231,9 +231,9 @@ public class EwsServiceXmlWriter implements IDisposable {
   /**
    * Writes the attribute value.
    *
-   * @param namespacePrefix The namespace prefix.
-   * @param localName       The local name of the attribute.
-   * @param value           The value.
+   * @param namespacePrefix the namespace prefix
+   * @param localName       the local name of the attribute
+   * @param value           the value
    * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeAttributeValue(String namespacePrefix, String localName,
@@ -258,7 +258,7 @@ public class EwsServiceXmlWriter implements IDisposable {
    *
    * @param localName   The local name of the attribute.
    * @param stringValue The string value.
-   * @throws ServiceXmlSerializationException Thrown if string value isn't valid for XML.
+   * @throws ServiceXmlSerializationException Thrown if string value isn't valid for XML
    */
   protected void writeAttributeString(String localName, String stringValue)
       throws ServiceXmlSerializationException {
@@ -316,13 +316,12 @@ public class EwsServiceXmlWriter implements IDisposable {
   /**
    * Writes the element value.
    *
-   * @param xmlNamespace The XML namespace.
-   * @param localName    The local name of the element.
-   * @param displayName  The name that should appear in the exception message when the
-   *                     value can not be serialized.
-   * @param value        The value.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param xmlNamespace the XML namespace
+   * @param localName    the local name of the element
+   * @param displayName  the name that should appear in the exception message when the value can not be serialized
+   * @param value        the value
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeElementValue(XmlNamespace xmlNamespace, String localName, String displayName, Object value)
       throws XMLStreamException, ServiceXmlSerializationException {
@@ -348,14 +347,13 @@ public class EwsServiceXmlWriter implements IDisposable {
   public void writeNode(Node xmlNode) throws XMLStreamException {
     if (xmlNode != null) {
       writeNode(xmlNode, this.xmlWriter);
-      //this.xmlWriter.writeCharacters(xmlNode.);
-      //this.xmlWriter.writeDTD(xmlNode);
-      //xmlNode.WriteTo(this.xmlWriter);
     }
   }
 
   /**
-   * @throws javax.xml.stream.XMLStreamException
+   * @param xmlNode XML node
+   * @param xmlStreamWriter XML stream writer
+   * @throws XMLStreamException the XML stream exception
    */
   public static void writeNode(Node xmlNode, XMLStreamWriter xmlStreamWriter)
       throws XMLStreamException {
@@ -379,7 +377,9 @@ public class EwsServiceXmlWriter implements IDisposable {
   }
 
   /**
-   * @throws javax.xml.stream.XMLStreamException
+   * @param document XML document
+   * @param xmlStreamWriter XML stream writer
+   * @throws XMLStreamException the XML stream exception
    */
   public static void writeToDocument(Document document,
       XMLStreamWriter xmlStreamWriter) throws XMLStreamException {
@@ -391,7 +391,9 @@ public class EwsServiceXmlWriter implements IDisposable {
   }
 
   /**
-   * @throws javax.xml.stream.XMLStreamException
+   * @param element DOM element
+   * @param writer XML stream writer
+   * @throws XMLStreamException the XML stream exception
    */
   public static void addElement(Element element, XMLStreamWriter writer)
       throws XMLStreamException {
@@ -474,11 +476,11 @@ public class EwsServiceXmlWriter implements IDisposable {
   /**
    * Writes the element value.
    *
-   * @param xmlNamespace The XML namespace.
-   * @param localName    The local name of the element.
-   * @param value        The value.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @param xmlNamespace the XML namespace
+   * @param localName    the local name of the element
+   * @param value        the value
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeElementValue(XmlNamespace xmlNamespace, String localName,
       Object value) throws XMLStreamException,
@@ -489,8 +491,8 @@ public class EwsServiceXmlWriter implements IDisposable {
   /**
    * Writes the base64-encoded element value.
    *
-   * @param buffer The buffer.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @param buffer the buffer
+   * @throws XMLStreamException the XML stream exception
    */
   public void writeBase64ElementValue(byte[] buffer)
       throws XMLStreamException {
@@ -502,9 +504,9 @@ public class EwsServiceXmlWriter implements IDisposable {
   /**
    * Writes the base64-encoded element value.
    *
-   * @param stream The stream.
-   * @throws java.io.IOException                 Signals that an I/O exception has occurred.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @param stream the stream
+   * @throws IOException signals that an I/O exception has occurred
+   * @throws XMLStreamException the XML stream exception
    */
   public void writeBase64ElementValue(InputStream stream) throws IOException,
       XMLStreamException {
@@ -582,7 +584,7 @@ public class EwsServiceXmlWriter implements IDisposable {
   /**
    * Write start document.
    *
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws XMLStreamException the XML stream exception
    */
   public void writeStartDocument() throws XMLStreamException {
     this.xmlWriter.writeStartDocument("utf-8", "1.0");

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsUtilities.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsUtilities.java
@@ -511,9 +511,10 @@ public final class EwsUtilities {
   /**
    * Write trace start element.
    *
-   * @param writer         The writer to write the start element to.
-   * @param traceTag       The trace tag.
-   * @param includeVersion If true, include build version attribute.
+   * @param writer         the writer to write the start element to
+   * @param traceTag       the trace tag
+   * @param includeVersion if true, include build version attribute
+   * @throws XMLStreamException the XML stream exception
    */
   private static void writeTraceStartElement(
       XMLStreamWriter writer,
@@ -539,8 +540,8 @@ public final class EwsUtilities {
    * @param entryKind the entry kind
    * @param logEntry  the log entry
    * @return the string
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws java.io.IOException                 Signals that an I/O exception has occurred.
+   * @throws XMLStreamException the XML stream exception
+   * @throws IOException signals that an I/O exception has occurred.
    */
   public static String formatLogMessage(String entryKind, String logEntry)
       throws XMLStreamException, IOException {

--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsXmlReader.java
@@ -82,7 +82,7 @@ public class EwsXmlReader {
    * Initializes a new instance of the EwsXmlReader class.
    *
    * @param stream the stream
-   * @throws Exception
+   * @throws Exception on error
    */
   public EwsXmlReader(InputStream stream) throws Exception {
     this.xmlReader = initializeXmlReader(stream);
@@ -93,14 +93,11 @@ public class EwsXmlReader {
    *
    * @param stream the stream
    * @return An XML reader to use.
-   * @throws Exception
+   * @throws Exception on error
    */
-  protected XMLEventReader initializeXmlReader(InputStream stream)
-      throws XMLStreamException, Exception {
-
+  protected XMLEventReader initializeXmlReader(InputStream stream) throws Exception {
     XMLInputFactory inputFactory = XMLInputFactory.newInstance();
     inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-    //inputFactory.setProperty(XMLInputFactory.RESOLVER, null);
 
     return inputFactory.createXMLEventReader(stream);
   }
@@ -178,7 +175,7 @@ public class EwsXmlReader {
    * Reads the specified node type.
    *
    * @throws ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws XMLStreamException the XML stream exception
    */
   public void read() throws ServiceXmlDeserializationException,
       XMLStreamException {
@@ -190,7 +187,7 @@ public class EwsXmlReader {
    *
    * @param keepWhiteSpace Do not remove whitespace characters if true
    * @throws ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws XMLStreamException the XML stream exception
    */
   private void read(boolean keepWhiteSpace) throws ServiceXmlDeserializationException,
       XMLStreamException {
@@ -431,8 +428,8 @@ public class EwsXmlReader {
    * Present event will be set on END ELEMENT
    *
    * @return String
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
    */
   public String readValue() throws XMLStreamException,
       ServiceXmlDeserializationException {
@@ -446,8 +443,8 @@ public class EwsXmlReader {
    *
    * @param keepWhiteSpace Do not remove whitespace characters if true
    * @return String
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
    */
   public String readValue(boolean keepWhiteSpace) throws XMLStreamException,
       ServiceXmlDeserializationException {
@@ -520,7 +517,7 @@ public class EwsXmlReader {
    *
    * @param value the value
    * @return boolean
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws XMLStreamException the XML stream exception
    * @throws ServiceXmlDeserializationException  the service xml deserialization exception
    */
   public boolean tryReadValue(OutParam<String> value)
@@ -555,9 +552,9 @@ public class EwsXmlReader {
    * Reads the base64 element value.
    *
    * @return byte[]
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws java.io.IOException                 Signals that an I/O exception has occurred.
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws IOException signals that an I/O exception has occurred
    */
   public byte[] readBase64ElementValue()
       throws ServiceXmlDeserializationException, XMLStreamException,
@@ -862,8 +859,8 @@ public class EwsXmlReader {
    * Outer XML as string.
    *
    * @return String
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   public String readOuterXml() throws ServiceXmlDeserializationException,
       XMLStreamException {
@@ -887,8 +884,8 @@ public class EwsXmlReader {
    * Reads the Inner XML at the given location.
    *
    * @return String
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   public String readInnerXml() throws ServiceXmlDeserializationException,
       XMLStreamException {
@@ -916,9 +913,7 @@ public class EwsXmlReader {
    * @param endEvent   the end event
    * @return true, if successful
    */
-  public static boolean checkEndElement(XMLEvent startEvent,
-      XMLEvent endEvent) {
-
+  public static boolean checkEndElement(XMLEvent startEvent, XMLEvent endEvent) {
     boolean isEndElement = false;
     if (endEvent.isEndElement()) {
       QName qEName = endEvent.asEndElement().getName();
@@ -936,13 +931,13 @@ public class EwsXmlReader {
    * Gets the XML reader for node.
    *
    * @return null
-   * @throws javax.xml.stream.XMLStreamException
-   * @throws ServiceXmlDeserializationException
-   * @throws java.io.FileNotFoundException
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
+   * @throws FileNotFoundException the file not found exception
    */
   public XMLEventReader getXmlReaderForNode()
       throws FileNotFoundException, ServiceXmlDeserializationException, XMLStreamException {
-    return readSubtree(); //this.xmlReader.ReadSubtree();
+    return readSubtree();
   }
 
   public XMLEventReader readSubtree()
@@ -986,9 +981,9 @@ public class EwsXmlReader {
    *
    * @param xmlNamespace The namespace of the element you with to move to.
    * @param localName    The local name of the element you wish to move to.
-   * @throws javax.xml.stream.XMLStreamException
+   * @throws XMLStreamException the XML stream exception
    */
-  public void ReadToDescendant(XmlNamespace xmlNamespace, String localName) throws XMLStreamException {
+  public void readToDescendant(XmlNamespace xmlNamespace, String localName) throws XMLStreamException {
     readToDescendant(localName, EwsUtilities.getNamespaceUri(xmlNamespace));
   }
 
@@ -1034,7 +1029,7 @@ public class EwsXmlReader {
    * Gets a value indicating whether current element is empty.
    *
    * @return boolean
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws XMLStreamException the XML stream exception
    */
   public boolean isEmptyElement() throws XMLStreamException {
     boolean isPresentStartElement = this.presentEvent.isStartElement();
@@ -1100,12 +1095,11 @@ public class EwsXmlReader {
    * Gets the type of the node.
    *
    * @return XmlNodeType
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws XMLStreamException the XML stream exception
    */
   public XmlNodeType getNodeType() throws XMLStreamException {
     XMLEvent event = this.presentEvent;
-    XmlNodeType nodeType = new XmlNodeType(event.getEventType());
-    return nodeType;
+    return new XmlNodeType(event.getEventType());
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
@@ -551,8 +551,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    *
    * @param folderId         The folder id
    * @param deleteMode       The delete mode
-   * @param deleteSubFolders if set to <c>true</c> empty folder should also delete sub
-   *                         folder.
+   * @param deleteSubFolders if set to "true" empty folder should also delete sub folder.
    * @throws Exception the exception
    */
   public void emptyFolder(FolderId folderId, DeleteMode deleteMode, boolean deleteSubFolders) throws Exception {
@@ -650,8 +649,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
       SendInvitationsMode sendInvitationsMode) throws Exception {
     ArrayList<Item> items = new ArrayList<Item>();
     items.add(item);
-    internalCreateItems(items, parentFolderId, messageDisposition,
-        sendInvitationsMode, ServiceErrorHandling.ThrowOnError);
+    internalCreateItems(items, parentFolderId, messageDisposition, sendInvitationsMode,
+                        ServiceErrorHandling.ThrowOnError);
   }
 
   /**
@@ -731,10 +730,9 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
           "This operation can't be performed because attachments have been added or deleted for one or more item.");
     }
 
-    return this.internalUpdateItems(items, savedItemsDestinationFolderId,
-        conflictResolution, messageDisposition,
-        sendInvitationsOrCancellationsMode,
-        ServiceErrorHandling.ReturnErrors);
+    return this.internalUpdateItems(items, savedItemsDestinationFolderId, conflictResolution,
+                                    messageDisposition, sendInvitationsOrCancellationsMode,
+                                    ServiceErrorHandling.ReturnErrors);
   }
 
   /**
@@ -835,16 +833,15 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    *                            not.
    * @return A ServiceResponseCollection providing copy results for each of
    * the specified item Ids.
-   * @throws Exception
+   * @throws Exception on error
    */
   public ServiceResponseCollection<MoveCopyItemResponse> copyItems(
       Iterable<ItemId> itemIds, FolderId destinationFolderId,
       boolean returnNewItemIds) throws Exception {
-    EwsUtilities.validateMethodVersion(this,
-        ExchangeVersion.Exchange2010_SP1, "CopyItems");
+    EwsUtilities.validateMethodVersion(this, ExchangeVersion.Exchange2010_SP1, "CopyItems");
 
-    return this.internalCopyItems(itemIds, destinationFolderId,
-        returnNewItemIds, ServiceErrorHandling.ReturnErrors);
+    return this.internalCopyItems(itemIds, destinationFolderId, returnNewItemIds,
+                                  ServiceErrorHandling.ReturnErrors);
   }
 
   /**
@@ -916,16 +913,15 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    *                            not.
    * @return A ServiceResponseCollection providing copy results for each of
    * the specified item Ids.
-   * @throws Exception
+   * @throws Exception on error
    */
   public ServiceResponseCollection<MoveCopyItemResponse> moveItems(
       Iterable<ItemId> itemIds, FolderId destinationFolderId,
       boolean returnNewItemIds) throws Exception {
-    EwsUtilities.validateMethodVersion(this,
-        ExchangeVersion.Exchange2010_SP1, "MoveItems");
+    EwsUtilities.validateMethodVersion(this, ExchangeVersion.Exchange2010_SP1, "MoveItems");
 
-    return this.internalMoveItems(itemIds, destinationFolderId,
-        returnNewItemIds, ServiceErrorHandling.ReturnErrors);
+    return this.internalMoveItems(itemIds, destinationFolderId, returnNewItemIds,
+                                  ServiceErrorHandling.ReturnErrors);
   }
 
   /**
@@ -1100,8 +1096,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
   public FindItemsResults<Item> findItems(
       WellKnownFolderName parentFolderName, ItemView view)
       throws Exception {
-    return this.findItems(new FolderId(parentFolderName),
-        (SearchFilter) null, view);
+    return this.findItems(new FolderId(parentFolderName), (SearchFilter) null, view);
   }
 
   /**
@@ -1242,8 +1237,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
   public GroupedFindItemsResults<Item> findItems(
       WellKnownFolderName parentFolderName, SearchFilter searchFilter,
       ItemView view, Grouping groupBy) throws Exception {
-    return this.findItems(new FolderId(parentFolderName), searchFilter,
-        view, groupBy);
+    return this.findItems(new FolderId(parentFolderName), searchFilter, view, groupBy);
   }
 
   /**
@@ -1283,8 +1277,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
   public FindItemsResults<Appointment> findAppointments(
       WellKnownFolderName parentFolderName, CalendarView calendarView)
       throws Exception {
-    return this.findAppointments(new FolderId(parentFolderName),
-        calendarView);
+    return this.findAppointments(new FolderId(parentFolderName), calendarView);
   }
 
   /**
@@ -1301,8 +1294,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
     EwsUtilities.validateParamCollection(items.iterator(), "item");
     EwsUtilities.validateParam(propertySet, "propertySet");
 
-    return this.internalLoadPropertiesForItems(items, propertySet,
-        ServiceErrorHandling.ReturnErrors);
+    return this.internalLoadPropertiesForItems(items, propertySet, ServiceErrorHandling.ReturnErrors);
   }
 
   /**
@@ -1360,8 +1352,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
     EwsUtilities.validateParamCollection(itemIds.iterator(), "itemIds");
     EwsUtilities.validateParam(propertySet, "propertySet");
 
-    return this.internalBindToItems(itemIds, propertySet,
-        ServiceErrorHandling.ReturnErrors);
+    return this.internalBindToItems(itemIds, propertySet, ServiceErrorHandling.ReturnErrors);
   }
 
   /**
@@ -1380,8 +1371,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
     List<ItemId> itmLst = new ArrayList<ItemId>();
     itmLst.add(itemId);
     ServiceResponseCollection<GetItemResponse> responses = this
-        .internalBindToItems(itmLst, propertySet,
-            ServiceErrorHandling.ThrowOnError);
+        .internalBindToItems(itmLst, propertySet, ServiceErrorHandling.ThrowOnError);
 
     return responses.getResponseAtIndex(0).getItem();
   }
@@ -1514,8 +1504,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    * @param attachments          the attachments
    * @param bodyType             the body type
    * @param additionalProperties the additional property
-   * @return Service response collection.
-   * @throws Exception
+   * @return service response collection
+   * @throws Exception on error
    */
   protected ServiceResponseCollection<GetAttachmentResponse> getAttachments(
       Attachment[] attachments, BodyType bodyType,
@@ -1540,8 +1530,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
     List<Attachment> attachmentArray = new ArrayList<Attachment>();
     attachmentArray.add(attachment);
 
-    this.internalGetAttachments(attachmentArray, bodyType,
-        additionalProperties, ServiceErrorHandling.ThrowOnError);
+    this.internalGetAttachments(attachmentArray, bodyType, additionalProperties,
+                                ServiceErrorHandling.ThrowOnError);
 
   }
 
@@ -1603,8 +1593,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    */
   public NameResolutionCollection resolveName(String nameToResolve)
       throws Exception {
-    return this.resolveName(nameToResolve,
-        ResolveNameSearchLocation.ContactsThenDirectory, false);
+    return this.resolveName(nameToResolve, ResolveNameSearchLocation.ContactsThenDirectory, false);
   }
 
   /**
@@ -1624,8 +1613,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
       Iterable<FolderId> parentFolderIds,
       ResolveNameSearchLocation searchScope, boolean returnContactDetails)
       throws Exception {
-    return resolveName(nameToResolve, parentFolderIds, searchScope,
-        returnContactDetails, null);
+    return resolveName(nameToResolve, parentFolderIds, searchScope, returnContactDetails, null);
 
   }
 
@@ -1641,9 +1629,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    * @param returnContactDetails   Indicates whether full contact information should be returned
    *                               for each of the found contacts.
    * @param contactDataPropertySet The property set for the contact details
-   * @return A collection of name resolutions whose names match the one
-   * passed as a parameter.
-   * @throws Exception
+   * @return a collection of name resolutions whose names match the one passed as a parameter
+   * @throws Exception on error
    */
   public NameResolutionCollection resolveName(String nameToResolve,
       Iterable<FolderId> parentFolderIds,
@@ -1683,7 +1670,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    * @param contactDataPropertySet The property set for the contact details
    * @return A collection of name resolutions whose names match the one
    * passed as a parameter.
-   * @throws Exception
+   * @throws Exception on error
    */
   public NameResolutionCollection resolveName(String nameToResolve,
       ResolveNameSearchLocation searchScope,
@@ -1708,8 +1695,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
   public NameResolutionCollection resolveName(String nameToResolve,
       ResolveNameSearchLocation searchScope, boolean returnContactDetails)
       throws Exception {
-    return this.resolveName(nameToResolve, null, searchScope,
-        returnContactDetails);
+    return this.resolveName(nameToResolve, null, searchScope, returnContactDetails);
   }
 
   /**
@@ -1780,12 +1766,10 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    *
    * @param mailboxSmtpAddress The e-mail address of the user.
    * @return The password expiration date
-   * @throws Exception
+   * @throws Exception on error
    */
-  public Date getPasswordExpirationDate(String mailboxSmtpAddress)
-      throws Exception {
-    GetPasswordExpirationDateRequest request = new GetPasswordExpirationDateRequest(
-        this);
+  public Date getPasswordExpirationDate(String mailboxSmtpAddress) throws Exception {
+    GetPasswordExpirationDateRequest request = new GetPasswordExpirationDateRequest(this);
     request.setMailboxSmtpAddress(mailboxSmtpAddress);
 
     return request.execute().getPasswordExpirationDate();
@@ -1802,7 +1786,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    *                   subscription.
    * @param eventTypes The event types to subscribe to.
    * @return A PullSubscription representing the new subscription.
-   * @throws Exception
+   * @throws Exception on error
    */
   public PullSubscription subscribeToPullNotifications(
       Iterable<FolderId> folderIds, int timeout, String watermark,
@@ -1835,8 +1819,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
       throws Exception {
     EwsUtilities.validateParamCollection(folderIds.iterator(), "folderIds");
 
-    return this.buildSubscribeToPullNotificationsRequest(folderIds,
-        timeout, watermark, eventTypes).beginExecute(callback, null);
+    return this.buildSubscribeToPullNotificationsRequest(folderIds, timeout, watermark,
+                                                         eventTypes).beginExecute(callback);
   }
 
   /**
@@ -1881,8 +1865,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
     EwsUtilities.validateMethodVersion(this, ExchangeVersion.Exchange2010,
         "BeginSubscribeToPullNotificationsOnAllFolders");
 
-    return this.buildSubscribeToPullNotificationsRequest(null, timeout,
-        watermark, eventTypes).beginExecute(null, null);
+    return this.buildSubscribeToPullNotificationsRequest(null, timeout, watermark, eventTypes).beginExecute(
+        null);
   }
 
   /**
@@ -1968,8 +1952,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    */
   public IAsyncResult beginUnsubscribe(AsyncCallback callback, Object state, String subscriptionId)
       throws Exception {
-    return this.buildUnsubscribeRequest(subscriptionId).beginExecute(
-        callback, null);
+    return this.buildUnsubscribeRequest(subscriptionId).beginExecute(callback);
   }
 
   /**
@@ -2034,7 +2017,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
   public IAsyncResult beginGetEvents(AsyncCallback callback, Object state, String subscriptionId,
       String watermark) throws Exception {
     return this.buildGetEventsRequest(subscriptionId, watermark)
-        .beginExecute(callback, null);
+        .beginExecute(callback);
   }
 
   /**
@@ -2094,8 +2077,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
     EwsUtilities.validateParamCollection(folderIds.iterator(), "folderIds");
 
     return this.buildSubscribeToPushNotificationsRequest(folderIds, url,
-        frequency, watermark, eventTypes).execute().getResponseAtIndex(
-        0).getSubscription();
+        frequency, watermark, eventTypes).execute().getResponseAtIndex(0).getSubscription();
   }
 
   /**
@@ -2121,8 +2103,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
       throws Exception {
     EwsUtilities.validateParamCollection(folderIds.iterator(), "folderIds");
 
-    return this.buildSubscribeToPushNotificationsRequest(folderIds, url,
-        frequency, watermark, eventTypes).beginExecute(callback, null);
+    return this.buildSubscribeToPushNotificationsRequest(folderIds, url, frequency, watermark,
+                                                         eventTypes).beginExecute(callback);
   }
 
   /**
@@ -2143,8 +2125,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
         "SubscribeToPushNotificationsOnAllFolders");
 
     return this.buildSubscribeToPushNotificationsRequest(null, url,
-        frequency, watermark, eventTypes).execute().getResponseAtIndex(
-        0).getSubscription();
+        frequency, watermark, eventTypes).execute().getResponseAtIndex(0).getSubscription();
   }
 
   /**
@@ -2170,8 +2151,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
     EwsUtilities.validateMethodVersion(this, ExchangeVersion.Exchange2010,
         "BeginSubscribeToPushNotificationsOnAllFolders");
 
-    return this.buildSubscribeToPushNotificationsRequest(null, url,
-        frequency, watermark, eventTypes).beginExecute(callback, null);
+    return this.buildSubscribeToPushNotificationsRequest(null, url, frequency, watermark,
+                                                         eventTypes).beginExecute(callback);
   }
 
 
@@ -2264,36 +2245,12 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
    */
   public StreamingSubscription subscribeToStreamingNotificationsOnAllFolders(
       EventType... eventTypes) throws Exception {
-    EwsUtilities.validateMethodVersion(this,
-        ExchangeVersion.Exchange2010_SP1,
-        "SubscribeToStreamingNotificationsOnAllFolders");
+    EwsUtilities.validateMethodVersion(this, ExchangeVersion.Exchange2010_SP1,
+                                       "SubscribeToStreamingNotificationsOnAllFolders");
 
     return this.buildSubscribeToStreamingNotificationsRequest(null,
         eventTypes).execute().getResponseAtIndex(0).getSubscription();
   }
-
-	/*
-	 * Subscribes to streaming notification. Calling this method results in a
-	 * call to EWS.
-	 * 
-	 * @param folderIds
-	 *            The Ids of the folder to subscribe to.
-	 * @param eventTypes
-	 *            The event types to subscribe to.
-	 * @return A StreamingSubscription representing the new subscription.
-	 * @throws Exception
-	public StreamingSubscription subscribeToStreamingNotifications(
-			Iterable<FolderId> folderIds, EventType... eventTypes)
-			throws Exception {
-		EwsUtilities.validateMethodVersion(this,
-				ExchangeVersion.Exchange2010_SP1,
-				"SubscribeToStreamingNotifications");
-
-		EwsUtilities.validateParamCollection(folderIds.iterator(), "folderIds");
-
-		return this.buildSubscribeToStreamingNotificationsRequest(folderIds,
-				eventTypes).execute().getResponseAtIndex(0).getSubscription();
-	}*/
 
   /**
    * Begins an asynchronous request to subscribe to streaming notification.
@@ -2316,28 +2273,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
     EwsUtilities.validateParamCollection(folderIds.iterator(), "folderIds");
 
     return this.buildSubscribeToStreamingNotificationsRequest(folderIds,
-        eventTypes).beginExecute(callback, null);
+        eventTypes).beginExecute(callback);
   }
-
-  /**
-   * Subscribes to streaming notification on all folder in the authenticated
-   * user's mailbox. Calling this method results in a call to EWS.
-   *
-   *@param eventTypes
-   *            The event types to subscribe to. @ returns A
-   *            StreamingSubscription representing the new subscription.
-   * @throws Exception
-   * @throws Exception
-   **/
-	/*public StreamingSubscription SubscribeToStreamingNotificationsOnAllFolders(
-			EventType... eventTypes) throws Exception, Exception {
-		EwsUtilities.validateMethodVersion(this,
-				ExchangeVersion.Exchange2010_SP1,
-				"SubscribeToStreamingNotificationsOnAllFolders");
-
-		return this.BuildSubscribeToStreamingNotificationsRequest(null,
-				eventTypes).execute().getResponseAtIndex(0).getSubscription();
-	}*/
 
   /**
    * Begins an asynchronous request to subscribe to streaming notification on
@@ -2356,7 +2293,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
         "BeginSubscribeToStreamingNotificationsOnAllFolders");
 
     return this.buildSubscribeToStreamingNotificationsRequest(null,
-        eventTypes).beginExecute(callback, null);
+        eventTypes).beginExecute(callback);
   }
 
   /**
@@ -2459,7 +2396,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
       SyncFolderItemsScope syncScope, String syncState) throws Exception {
     return this.buildSyncFolderItemsRequest(syncFolderId, propertySet,
         ignoredItemIds, maxChangesReturned, syncScope, syncState)
-        .beginExecute(callback, null);
+        .beginExecute(callback);
   }
 
   /**
@@ -2548,7 +2485,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
       PropertySet propertySet,
       String syncState) throws Exception {
     return this.buildSyncFolderHierarchyRequest(syncFolderId, propertySet,
-        syncState).beginExecute(callback, null);
+        syncState).beginExecute(callback);
   }
 
   /**
@@ -3887,8 +3824,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
   }
 
   /**
-   * Sets the DateTime precision for DateTime values
-   * Web Services.
+   * Sets the DateTime precision for DateTime values Web Services.
+   * @param d date time precision
    */
   public void setDateTimePrecision(DateTimePrecision d) {
     this.dateTimePrecision = d;

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
@@ -201,7 +201,7 @@ public abstract class ExchangeServiceBase implements Closeable {
   }
 
   /**
-   * Create registry with configured {@see ConnectionSocketFactory} instances.
+   * Create registry with configured {@link ConnectionSocketFactory} instances.
    * Override this method to change how to work with different schemas.
    *
    * @return registry object
@@ -327,7 +327,11 @@ public abstract class ExchangeServiceBase implements Closeable {
    * 500 ISE typically indicates that a SOAP fault has occurred and the handling of
    * a SOAP fault is currently service specific.
    *
-   * @throws Exception
+   * @param httpWebResponse HTTP web response
+   * @param webException web exception
+   * @param responseHeadersTraceFlag trace flag for response headers
+   * @param responseTraceFlag trace flag for respone
+   * @throws Exception on error
    */
   protected void internalProcessHttpErrorResponse(HttpWebRequest httpWebResponse, Exception webException,
       TraceFlags responseHeadersTraceFlag, TraceFlags responseTraceFlag) throws Exception {
@@ -354,8 +358,8 @@ public abstract class ExchangeServiceBase implements Closeable {
   }
 
   /**
-   * @return false if location is null,true if this abstract pathname is
-   * absolute,
+   * @param location file path
+   * @return false if location is null,true if this abstract pathname is absolute
    */
   public static boolean checkURIPath(String location) {
     if (location == null) {
@@ -366,7 +370,9 @@ public abstract class ExchangeServiceBase implements Closeable {
   }
 
   /**
-   * @throws Exception
+   * @param httpWebResponse HTTP web response
+   * @param webException web exception
+   * @throws Exception on error
    */
   protected abstract void processHttpErrorResponse(HttpWebRequest httpWebResponse, Exception webException)
       throws Exception;
@@ -384,10 +390,10 @@ public abstract class ExchangeServiceBase implements Closeable {
   /**
    * Logs the specified string to the TraceListener if tracing is enabled.
    *
-   * @param traceType Kind of trace entry.
-   * @param logEntry  The entry to log.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws java.io.IOException                 Signals that an I/O exception has occurred.
+   * @param traceType kind of trace entry
+   * @param logEntry the entry to log
+   * @throws XMLStreamException the XML stream exception
+   * @throws IOException signals that an I/O exception has occurred
    */
   public void traceMessage(TraceFlags traceType, String logEntry) throws XMLStreamException, IOException {
     if (this.isTraceEnabledFor(traceType)) {
@@ -416,10 +422,10 @@ public abstract class ExchangeServiceBase implements Closeable {
    *
    * @param traceType Kind of trace entry.
    * @param request   The request
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException
-   * @throws java.net.URISyntaxException
-   * @throws java.io.IOException
-   * @throws javax.xml.stream.XMLStreamException
+   * @throws EWSHttpException eWS http exception
+   * @throws URISyntaxException URI syntax error
+   * @throws IOException signals that an I/O exception has occurred
+   * @throws XMLStreamException the XML stream exception
    */
   public void traceHttpRequestHeaders(TraceFlags traceType, HttpWebRequest request)
       throws URISyntaxException, EWSHttpException, XMLStreamException, IOException {
@@ -434,11 +440,11 @@ public abstract class ExchangeServiceBase implements Closeable {
   /**
    * Traces the HTTP response headers.
    *
-   * @param traceType Kind of trace entry.
-   * @param request   The HttpRequest object.
-   * @throws javax.xml.stream.XMLStreamException                  the xML stream exception
-   * @throws java.io.IOException                                  Signals that an I/O exception has occurred.
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException the eWS http exception
+   * @param traceType kind of trace entry
+   * @param request the HttpRequest object
+   * @throws XMLStreamException the XML stream exception
+   * @throws IOException signals that an I/O exception has occurred
+   * @throws EWSHttpException the eWS http exception
    */
   private void traceHttpResponseHeaders(TraceFlags traceType, HttpWebRequest request)
       throws XMLStreamException, IOException, EWSHttpException {
@@ -485,56 +491,6 @@ public abstract class ExchangeServiceBase implements Closeable {
       }
     }
   }
-
-//  /**
-//   * Gets the cookie container. <value>The cookie container.</value>
-//   *
-//   * @param url   the url
-//   * @param value the value
-//   * @throws java.io.IOException         , URISyntaxException
-//   * @throws java.net.URISyntaxException the uRI syntax exception
-//   */
-//  public void setCookie(URL url, String value) throws IOException,
-//      URISyntaxException {
-//    CookieHandler handler = CookieHandler.getDefault();
-//    if (handler != null) {
-//      Map<String, List<String>> headers =
-//          new HashMap<String, List<String>>();
-//      List<String> values = new Vector<String>();
-//      values.add(value);
-//      headers.put("Cookie", values);
-//
-//      handler.put(url.toURI(), headers);
-//    }
-//  }
-//
-//  /**
-//   * Gets the cookie.
-//   *
-//   * @param url the url
-//   * @return the cookie
-//   * @throws java.io.IOException         Signals that an I/O exception has occurred.
-//   * @throws java.net.URISyntaxException the uRI syntax exception
-//   */
-//  public String getCookie(URL url) throws IOException, URISyntaxException {
-//    String cookieValue = null;
-//
-//    CookieHandler handler = CookieHandler.getDefault();
-//    if (handler != null) {
-//      Map<String, List<String>> headers = handler.get(url.toURI(),
-//          new HashMap<String, List<String>>());
-//      List<String> values = headers.get("Cookie");
-//      for (Iterator<String> iter = values.iterator(); iter.hasNext(); ) {
-//        String v = iter.next();
-//
-//        if (cookieValue == null)
-//          cookieValue = v;
-//        else
-//          cookieValue = cookieValue + ";" + v;
-//      }
-//    }
-//    return cookieValue;
-//  }
 
   /**
    * Gets a value indicating whether tracing is enabled.
@@ -822,9 +778,9 @@ public abstract class ExchangeServiceBase implements Closeable {
    *
    * @param traceType kind of trace entry
    * @param request   The request
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException
-   * @throws java.io.IOException
-   * @throws javax.xml.stream.XMLStreamException
+   * @throws EWSHttpException eWS http exception
+   * @throws IOException signals that an I/O exception has occurred
+   * @throws XMLStreamException the XML stream exception
    */
   public void processHttpResponseHeaders(TraceFlags traceType, HttpWebRequest request)
       throws XMLStreamException, IOException, EWSHttpException {
@@ -847,6 +803,7 @@ public abstract class ExchangeServiceBase implements Closeable {
 
   /**
    * Gets a collection of HTTP headers from the last response.
+   * @return HTTP response headers
    */
   public Map<String, String> getHttpResponseHeaders() {
     return this.httpResponseHeaders;
@@ -854,6 +811,7 @@ public abstract class ExchangeServiceBase implements Closeable {
 
   /**
    * Gets the session key.
+   * @return session key
    */
   public static byte[] getSessionKey() {
     // this has to be computed only once.

--- a/src/main/java/microsoft/exchange/webservices/data/core/ICustomXmlUpdateSerializer.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ICustomXmlUpdateSerializer.java
@@ -24,11 +24,7 @@
 package microsoft.exchange.webservices.data.core;
 
 import microsoft.exchange.webservices.data.core.service.ServiceObject;
-import microsoft.exchange.webservices.data.exception.ServiceValidationException;
-import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
 import microsoft.exchange.webservices.data.property.definition.PropertyDefinition;
-
-import javax.xml.stream.XMLStreamException;
 
 /**
  * Interface defined for property that produce their own update serialization.
@@ -38,21 +34,14 @@ public interface ICustomXmlUpdateSerializer {
   /**
    * Writes the update to XML.
    *
-   * @param writer             The writer.
-   * @param ewsObject          The ews object.
-   * @param propertyDefinition Property definition.
-   * @return True if property generated serialization.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
-   * @throws InstantiationException              the instantiation exception
-   * @throws IllegalAccessException              the illegal access exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceValidationException          the service validation exception
-   * @throws Exception                           the exception
+   * @param writer the writer
+   * @param ewsObject The ews object
+   * @param propertyDefinition property definition
+   * @return true if property generated serialization
+   * @throws Exception the exception
    */
   boolean writeSetUpdateToXml(EwsServiceXmlWriter writer,
-      ServiceObject ewsObject, PropertyDefinition propertyDefinition)
-      throws XMLStreamException, ServiceXmlSerializationException,
-      InstantiationException, IllegalAccessException, ServiceValidationException, Exception;
+      ServiceObject ewsObject, PropertyDefinition propertyDefinition) throws Exception;
 
   /**
    * Writes the deletion update to XML.
@@ -60,11 +49,8 @@ public interface ICustomXmlUpdateSerializer {
    * @param writer    The writer.
    * @param ewsObject The ews object.
    * @return True if property generated serialization.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
-   * @throws Exception                           the exception
+   * @throws Exception the exception
    */
   boolean writeDeleteUpdateToXml(EwsServiceXmlWriter writer,
-      ServiceObject ewsObject) throws XMLStreamException,
-      ServiceXmlSerializationException, Exception;
+      ServiceObject ewsObject) throws Exception;
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/LazyMember.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/LazyMember.java
@@ -28,10 +28,11 @@ package microsoft.exchange.webservices.data.core;
  * access.
  *
  * @param <T> Type of the lazy member
- *            <p/>
+ *            <p>
  *            If we find ourselves creating a whole bunch of these in our code,
  *            we need to rethink this. Each lazy member holds the actual member
  *            and a delegate. That can turn into a whole lot of overhead
+ *            </p>
  */
 public class LazyMember<T> {
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/PropertyBag.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/PropertyBag.java
@@ -242,11 +242,11 @@ public class PropertyBag implements IComplexPropertyChanged, IComplexPropertyCha
   /**
    * Tries to get a property value based on a property definition.
    *
-   * @param <T>                The types of the property.
-   * @param propertyDefinition The property definition.
-   * @param propertyValue      The property value.
-   * @return True if property was retrieved.
-   * @throws microsoft.exchange.webservices.data.exception.ArgumentException
+   * @param <T>                the types of the property
+   * @param propertyDefinition the property definition
+   * @param propertyValue      the property value
+   * @return true if property was retrieved
+   * @throws ArgumentException on validation error
    */
   public <T> boolean tryGetPropertyType(Class<T> cls, PropertyDefinition propertyDefinition,
       OutParam<T> propertyValue) throws ArgumentException {
@@ -380,9 +380,9 @@ public class PropertyBag implements IComplexPropertyChanged, IComplexPropertyCha
   /**
    * Tries to retrieve the value of the specified property.
    *
-   * @param propertyDefinition    The property for which to retrieve a value.
-   * @param propertyValueOutParam If the method succeeds, contains the value of the property.
-   * @return True if the value could be retrieved, false otherwise.
+   * @param propertyDefinition the property for which to retrieve a value
+   * @param propertyValueOutParam if the method succeeds, contains the value of the property
+   * @return true if the value could be retrieved, false otherwise
    */
   public <T> boolean tryGetValue(PropertyDefinition propertyDefinition, OutParam<T> propertyValueOutParam) {
     if (this.properties.containsKey(propertyDefinition)) {

--- a/src/main/java/microsoft/exchange/webservices/data/core/PropertySet.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/PropertySet.java
@@ -441,12 +441,12 @@ public final class PropertySet implements ISelfValidate,
   }
 
   /**
-   * Writes additonal property to XML.
+   * Writes additional property to XML.
    *
-   * @param writer              The writer to write to.
-   * @param propertyDefinitions The property definitions to write.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer              The writer to write to
+   * @param propertyDefinitions The property definitions to write
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public static void writeAdditionalPropertiesToXml(EwsServiceXmlWriter writer,
       Iterator<PropertyDefinitionBase> propertyDefinitions)
@@ -533,10 +533,10 @@ public final class PropertySet implements ISelfValidate,
   /**
    * Writes the property set to XML.
    *
-   * @param writer            The writer to write to.
-   * @param serviceObjectType The type of service object the property set is emitted for.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer            The writer to write to
+   * @param serviceObjectType The type of service object the property set is emitted for
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeToXml(EwsServiceXmlWriter writer, ServiceObjectType serviceObjectType) throws XMLStreamException, ServiceXmlSerializationException {
     writer

--- a/src/main/java/microsoft/exchange/webservices/data/core/WebAsyncCallStateAnchor.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/WebAsyncCallStateAnchor.java
@@ -34,9 +34,6 @@ public class WebAsyncCallStateAnchor {
   AsyncCallback asyncCallback;
   Object asyncState;
 
-  /**
-   * Construtctor
-   */
   public WebAsyncCallStateAnchor(ServiceRequestBase serviceRequest,
       HttpWebRequest webRequest,
       AsyncCallback asyncCallback,

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ConvertIdRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ConvertIdRequest.java
@@ -136,8 +136,8 @@ public final class ConvertIdRequest extends
    * Writes XML elements.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected void writeElementsToXml(EwsServiceXmlWriter writer)
@@ -164,8 +164,7 @@ public final class ConvertIdRequest extends
   }
 
   /**
-   * Gets the destination format. <value>The destination
-   * format.</value>
+   * Gets the destination format.
    *
    * @return the destination format
    */
@@ -183,7 +182,7 @@ public final class ConvertIdRequest extends
   }
 
   /**
-   * Gets the ids. <value>The ids.</value>
+   * Gets the ids.
    *
    * @return the ids
    */

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/DeleteUserConfigurationRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/DeleteUserConfigurationRequest.java
@@ -144,7 +144,7 @@ public class DeleteUserConfigurationRequest extends
    * Initializes a new instance of the class.
    *
    * @param service the service
-   * @throws Exception
+   * @throws Exception on error
    */
   public DeleteUserConfigurationRequest(ExchangeService service)
       throws Exception {
@@ -152,7 +152,7 @@ public class DeleteUserConfigurationRequest extends
   }
 
   /**
-   * Gets  the name. <value>The name.</value>
+   * Gets  the name.
    *
    * @return the name
    */
@@ -170,8 +170,7 @@ public class DeleteUserConfigurationRequest extends
   }
 
   /**
-   * Gets  the parent folThe parent folder Id. <value>The parent folder
-   * Id.</value>
+   * Gets the parent folThe parent folder Id.
    *
    * @return the parent folder id
    */

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/EmptyFolderRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/EmptyFolderRequest.java
@@ -32,7 +32,6 @@ import microsoft.exchange.webservices.data.core.response.ServiceResponse;
 import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.ServiceErrorHandling;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
-import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
 import microsoft.exchange.webservices.data.misc.FolderIdWrapperList;
 
@@ -49,7 +48,7 @@ public final class EmptyFolderRequest extends DeleteRequest<ServiceResponse> {
    *
    * @param service           The service.
    * @param errorHandlingMode Indicates how errors should be handled.
-   * @throws Exception
+   * @throws Exception on error
    */
   public EmptyFolderRequest(ExchangeService service, ServiceErrorHandling errorHandlingMode)
       throws Exception {
@@ -59,11 +58,10 @@ public final class EmptyFolderRequest extends DeleteRequest<ServiceResponse> {
   /**
    * Validates request.
    *
-   * @throws Exception
-   * @throws ServiceLocalException
+   * @throws Exception on error
    */
   @Override
-  protected void validate() throws ServiceLocalException, Exception {
+  protected void validate() throws Exception {
     super.validate();
     EwsUtilities.validateParam(this.getFolderIds(), "FolderIds");
     this.getFolderIds().validate(this.getService().
@@ -73,7 +71,7 @@ public final class EmptyFolderRequest extends DeleteRequest<ServiceResponse> {
   /**
    * Gets the expected response message count.
    *
-   * @return Number of expected response messages.</returns>
+   * @return Number of expected response messages.
    */
   @Override
   protected int getExpectedResponseMessageCount() {
@@ -141,7 +139,7 @@ public final class EmptyFolderRequest extends DeleteRequest<ServiceResponse> {
    * Writes XML attribute.
    *
    * @param writer The writer.
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException
+   * @throws ServiceXmlSerializationException
    */
   @Override
   protected void writeAttributesToXml(EwsServiceXmlWriter writer)
@@ -154,8 +152,7 @@ public final class EmptyFolderRequest extends DeleteRequest<ServiceResponse> {
   /**
    * Gets the request version.
    *
-   * @return Earliest Exchange version
-   * in which this request is supported.
+   * @return Earliest Exchange version in which this request is supported.
    */
   @Override
   protected ExchangeVersion getMinimumRequiredServerVersion() {
@@ -172,22 +169,18 @@ public final class EmptyFolderRequest extends DeleteRequest<ServiceResponse> {
   }
 
   /**
-   * Gets a value indicating whether empty
-   * folder should also delete sub folder.
+   * Gets a value indicating whether empty folder should also delete sub folder.
    *
-   * @value true if empty folder should also
-   * delete sub folder, otherwise false.
+   * @value true if empty folder should also delete sub folder, otherwise false.
    */
   protected boolean getDeleteSubFolders() {
     return deleteSubFolders;
   }
 
   /**
-   * Sets a value indicating whether empty
-   * folder should also delete sub folder.
+   * Sets a value indicating whether empty folder should also delete sub folder.
    *
-   * @value true if empty folder should also
-   * delete sub folder, otherwise false.
+   * @value true if empty folder should also delete sub folder, otherwise false.
    */
   public void setDeleteSubFolders(boolean value) {
     this.deleteSubFolders = value;

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ExecuteDiagnosticMethodRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ExecuteDiagnosticMethodRequest.java
@@ -67,7 +67,7 @@ public final class ExecuteDiagnosticMethodRequest extends
    * Writes XML elements.
    *
    * @param writer The writer
-   * @throws javax.xml.stream.XMLStreamException
+   * @throws XMLStreamException the XML stream exception
    * @throws ServiceXmlSerializationException
    */
   @Override

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ExpandGroupRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ExpandGroupRequest.java
@@ -136,7 +136,7 @@ public class ExpandGroupRequest extends
    * Initializes a new instance of the class.
    *
    * @param service the service
-   * @throws Exception
+   * @throws Exception on error
    */
   public ExpandGroupRequest(ExchangeService service)
       throws Exception {
@@ -144,7 +144,7 @@ public class ExpandGroupRequest extends
   }
 
   /**
-   * Gets  the email address. <value>The email address.</value>
+   * Gets  the email address.
    *
    * @return the email address
    */

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetAttachmentRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetAttachmentRequest.java
@@ -148,9 +148,9 @@ public final class GetAttachmentRequest extends
   /**
    * Writes XML elements.
    *
-   * @param writer The writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetEventsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetEventsRequest.java
@@ -130,8 +130,8 @@ public class GetEventsRequest extends MultiResponseServiceRequest<GetEventsRespo
    * Writes the elements to XML writer.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetInboxRulesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetInboxRulesRequest.java
@@ -85,8 +85,8 @@ public final class GetInboxRulesRequest extends SimpleServiceRequestBase<GetInbo
    * Writes XML elements.
    *
    * @param writer The writer.
-   * @throws javax.xml.stream.XMLStreamException
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException
    */
   @Override
   protected void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetPasswordExpirationDateRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetPasswordExpirationDateRequest.java
@@ -30,11 +30,6 @@ import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.core.response.GetPasswordExpirationDateResponse;
 import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
-import microsoft.exchange.webservices.data.exception.ServiceLocalException;
-import microsoft.exchange.webservices.data.exception.ServiceValidationException;
-import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
-
-import javax.xml.stream.XMLStreamException;
 
 public final class GetPasswordExpirationDateRequest extends SimpleServiceRequestBase<GetPasswordExpirationDateResponse> {
 
@@ -66,9 +61,7 @@ public final class GetPasswordExpirationDateRequest extends SimpleServiceRequest
   }
 
   @Override
-  protected void writeElementsToXml(EwsServiceXmlWriter writer)
-      throws XMLStreamException, ServiceXmlSerializationException, ServiceLocalException, InstantiationException,
-      IllegalAccessException, ServiceValidationException, Exception {
+  protected void writeElementsToXml(EwsServiceXmlWriter writer) throws Exception {
     writer.writeElementValue(XmlNamespace.Messages,
         XmlElementNames.MailboxSmtpAddress,
         this.getMailboxSmtpAddress());

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetServerTimeZonesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetServerTimeZonesRequest.java
@@ -136,8 +136,8 @@ class GetServerTimeZonesRequest extends
    * Writes XML elements.
    *
    * @param writer the writer
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   @Override
   protected void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetStreamingEventsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetStreamingEventsRequest.java
@@ -86,8 +86,8 @@ public class GetStreamingEventsRequest extends HangingServiceRequestBase<GetStre
   /**
    * Writes the elements to XML writer.
    *
-   * @param writer The writer
-   * @throws javax.xml.stream.XMLStreamException
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
    * @throws ServiceXmlSerializationException
    */
   @Override

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetUserOofSettingsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetUserOofSettingsRequest.java
@@ -73,8 +73,8 @@ public final class GetUserOofSettingsRequest extends SimpleServiceRequestBase<Ge
    * Validate request.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/HangingServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/HangingServiceRequestBase.java
@@ -113,8 +113,8 @@ public abstract class HangingServiceRequestBase<T> extends ServiceRequestBase<T>
     /**
      * Delegate method to handle a hanging request disconnection.
      *
-     * @param sender The object invoking the delegate.
-     * @param args,  Event data.
+     * @param sender the object invoking the delegate
+     * @param args event data
      */
     void hangingRequestDisconnectHandler(Object sender,
         HangingRequestDisconnectEventArgs args);
@@ -323,6 +323,7 @@ public abstract class HangingServiceRequestBase<T> extends ServiceRequestBase<T>
 
   /**
    * Perform any bookkeeping needed when we connect
+   * @throws XMLStreamException the XML stream exception
    */
   private void internalOnConnect() throws XMLStreamException,
       IOException, EWSHttpException {

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/HttpWebRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/HttpWebRequest.java
@@ -24,7 +24,6 @@
 package microsoft.exchange.webservices.data.core.request;
 
 import microsoft.exchange.webservices.data.EWSConstants;
-import microsoft.exchange.webservices.data.core.WebAsyncCallStateAnchor;
 import microsoft.exchange.webservices.data.core.WebProxy;
 import microsoft.exchange.webservices.data.exception.EWSHttpException;
 import microsoft.exchange.webservices.data.misc.IAsyncResult;
@@ -472,8 +471,8 @@ public abstract class HttpWebRequest {
    * Gets the input stream.
    *
    * @return the input stream
-   * @throws EWSHttpException    the eWS http exception
-   * @throws java.io.IOException
+   * @throws EWSHttpException the eWS http exception
+   * @throws IOException the IO exception
    */
   public abstract InputStream getInputStream() throws EWSHttpException, IOException;
 
@@ -481,7 +480,7 @@ public abstract class HttpWebRequest {
    * Gets the error stream.
    *
    * @return the error stream
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException the eWS http exception
+   * @throws EWSHttpException the eWS http exception
    */
   public abstract InputStream getErrorStream() throws EWSHttpException;
 
@@ -489,7 +488,7 @@ public abstract class HttpWebRequest {
    * Gets the output stream.
    *
    * @return the output stream
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException the eWS http exception
+   * @throws EWSHttpException the eWS http exception
    */
   public abstract OutputStream getOutputStream() throws EWSHttpException;
 
@@ -532,7 +531,7 @@ public abstract class HttpWebRequest {
    * Gets the response code.
    *
    * @return the response code
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException the eWS http exception
+   * @throws EWSHttpException the eWS http exception
    */
   public abstract int getResponseCode() throws EWSHttpException;
 
@@ -540,7 +539,7 @@ public abstract class HttpWebRequest {
    * Gets the response message.
    *
    * @return the response message
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException the eWS http exception
+   * @throws EWSHttpException the eWS http exception
    */
   public abstract String getResponseText() throws EWSHttpException;
 
@@ -549,7 +548,7 @@ public abstract class HttpWebRequest {
    *
    * @param headerName the header name
    * @return the response header field
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException the eWS http exception
+   * @throws EWSHttpException the eWS http exception
    */
   public abstract String getResponseHeaderField(String headerName)
       throws EWSHttpException;
@@ -567,25 +566,8 @@ public abstract class HttpWebRequest {
    * Executes Request by sending request xml data to server.
    *
    * @throws EWSHttpException    the eWS http exception
-   * @throws HttpException       the http exception
    * @throws java.io.IOException the IO Exception
    */
   public abstract int executeRequest() throws EWSHttpException, IOException;
-
-  public IAsyncResult beginGetResponse(Object webRequestAsyncCallback,
-      WebAsyncCallStateAnchor wrappedState) {
-    // TODO Auto-generated method stub
-    return null;
-  }
-
-
-
-  public ByteArrayOutputStream endGetRequestStream(
-      IAsyncResult result) {
-    // TODO Auto-generated method stub
-    return new ByteArrayOutputStream();
-  }
-
-
 
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/MoveCopyItemRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/MoveCopyItemRequest.java
@@ -59,7 +59,7 @@ public abstract class MoveCopyItemRequest<TResponse extends ServiceResponse>
    *
    * @param service           the service
    * @param errorHandlingMode the error handling mode
-   * @throws Exception
+   * @throws Exception on error
    */
   protected MoveCopyItemRequest(ExchangeService service,
       ServiceErrorHandling errorHandlingMode)
@@ -96,7 +96,7 @@ public abstract class MoveCopyItemRequest<TResponse extends ServiceResponse>
   }
 
   /**
-   * Gets the item ids. <value>The item ids.</value>
+   * Gets the item ids.
    *
    * @return the item ids
    */

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/MultiResponseServiceRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/MultiResponseServiceRequest.java
@@ -173,6 +173,7 @@ public abstract class MultiResponseServiceRequest<TResponse extends ServiceRespo
    *
    * @param asyncResult The async result
    * @return Service response collection.
+   * @throws Exception on error
    */
   public ServiceResponseCollection<TResponse> endExecute(IAsyncResult asyncResult) throws Exception {
     ServiceResponseCollection<TResponse> serviceResponses = endInternalExecute(asyncResult);

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/RemoveDelegateRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/RemoveDelegateRequest.java
@@ -129,7 +129,7 @@ public class RemoveDelegateRequest extends
   }
 
   /**
-   * Gets the user ids. <value>The user ids.</value>
+   * Gets the user ids.
    *
    * @return the user ids
    */

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ResolveNamesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ResolveNamesRequest.java
@@ -248,7 +248,7 @@ public final class ResolveNamesRequest extends
   }
 
   /**
-   * Gets the name to resolve. <value>The name to resolve.</value>
+   * Gets the name to resolve.
    *
    * @return the name to resolve
    */
@@ -266,9 +266,8 @@ public final class ResolveNamesRequest extends
   }
 
   /**
-   * Gets a value indicating whether to return full contact data or
-   * not. <value> <c>true</c> if should return full contact data; otherwise,
-   * <c>false</c>. </value>
+   * Gets a value indicating whether to return full contact data or not.
+   * "true" if should return full contact data; otherwise, "false".
    *
    * @return the return full contact data
    */
@@ -286,7 +285,7 @@ public final class ResolveNamesRequest extends
   }
 
   /**
-   * Gets the search location. <value>The search scope.</value>
+   * Gets the search location.
    *
    * @return the search location
    */
@@ -304,7 +303,7 @@ public final class ResolveNamesRequest extends
   }
 
   /**
-   * Gets the parent folder ids. <value>The parent folder ids.</value>
+   * Gets the parent folder ids.
    *
    * @return the parent folder ids
    */
@@ -331,7 +330,5 @@ public final class ResolveNamesRequest extends
   public PropertySet getContactDataPropertySet() {
     return this.contactDataPropertySet;
   }
-
-
 
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/SendItemRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/SendItemRequest.java
@@ -33,7 +33,6 @@ import microsoft.exchange.webservices.data.core.service.item.Item;
 import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.ServiceErrorHandling;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
-import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
 import microsoft.exchange.webservices.data.property.complex.FolderId;
 
@@ -140,12 +139,10 @@ public final class SendItemRequest extends
    * Writes the elements to XML.
    *
    * @param writer the writer
-   * @throws ServiceLocalException the service local exception
-   * @throws Exception             the exception
+   * @throws Exception the exception
    */
   @Override
-  protected void writeElementsToXml(EwsServiceXmlWriter writer)
-      throws ServiceLocalException, Exception {
+  protected void writeElementsToXml(EwsServiceXmlWriter writer) throws Exception {
     writer
         .writeStartElement(XmlNamespace.Messages,
             XmlElementNames.ItemIds);
@@ -205,8 +202,7 @@ public final class SendItemRequest extends
   }
 
   /**
-   * Gets the saved copy destination folder id. <value>The saved
-   * copy destination folder id.</value>
+   * Gets the saved copy destination folder id.
    *
    * @return the saved copy destination folder id
    */

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
@@ -40,7 +40,6 @@ import microsoft.exchange.webservices.data.exception.HttpErrorException;
 import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.ServiceRequestException;
 import microsoft.exchange.webservices.data.exception.ServiceResponseException;
-import microsoft.exchange.webservices.data.exception.ServiceValidationException;
 import microsoft.exchange.webservices.data.exception.ServiceVersionException;
 import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
 import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
@@ -68,12 +67,6 @@ import java.util.zip.InflaterInputStream;
 public abstract class ServiceRequestBase<T> {
 
   private static final Log LOG = LogFactory.getLog(ServiceRequestBase.class);
-
-  // Private Constants
-  // private final String XMLSchemaNamespace =
-  // "http://www.w3.org/2001/XMLSchema";
-  // private final String XMLSchemaInstanceNamespace =
-  // "http://www.w3.org/2001/XMLSchema-instance";
 
   /**
    * The service.
@@ -117,18 +110,9 @@ public abstract class ServiceRequestBase<T> {
    * Writes XML elements.
    *
    * @param writer The writer.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
-   * @throws ServiceLocalException               the service local exception
-   * @throws InstantiationException              the instantiation exception
-   * @throws IllegalAccessException              the illegal access exception
-   * @throws ServiceValidationException          the service validation exception
-   * @throws Exception                           the exception
+   * @throws Exception the exception
    */
-  protected abstract void writeElementsToXml(EwsServiceXmlWriter writer)
-      throws XMLStreamException, ServiceXmlSerializationException,
-      ServiceLocalException, InstantiationException,
-      IllegalAccessException, ServiceValidationException, Exception;
+  protected abstract void writeElementsToXml(EwsServiceXmlWriter writer) throws Exception;
 
   /**
    * Validate request.
@@ -136,7 +120,7 @@ public abstract class ServiceRequestBase<T> {
    * @throws ServiceLocalException the service local exception
    * @throws Exception             the exception
    */
-  protected void validate() throws ServiceLocalException, Exception {
+  protected void validate() throws Exception {
     this.service.validate();
   }
 
@@ -348,11 +332,11 @@ public abstract class ServiceRequestBase<T> {
   /**
    * Traces the response.
    *
-   * @param request      The response.
-   * @param memoryStream The response content in a MemoryStream.
-   * @throws javax.xml.stream.XMLStreamException                  the xML stream exception
-   * @throws java.io.IOException                                  Signals that an I/O exception has occurred.
-   * @throws microsoft.exchange.webservices.data.exception.EWSHttpException the eWS http exception
+   * @param request the response
+   * @param memoryStream the response content in a MemoryStream
+   * @throws XMLStreamException the XML stream exception
+   * @throws IOException signals that an I/O exception has occurred
+   * @throws EWSHttpException the eWS http exception
    */
   protected void traceResponse(HttpWebRequest request,
       ByteArrayOutputStream memoryStream) throws XMLStreamException,
@@ -404,15 +388,14 @@ public abstract class ServiceRequestBase<T> {
   /**
    * Reads the response.
    *
-   * @return serviceResponse
-   * @throws Exception
+   * @param response HTTP web request
+   * @return response response object
+   * @throws Exception on error
    */
   protected T readResponse(HttpWebRequest response) throws Exception {
     T serviceResponse;
 
     if (!response.getResponseContentType().startsWith("text/xml")) {
-      String line = new BufferedReader(new InputStreamReader(ServiceRequestBase.getResponseStream(response)))
-          .readLine();
       throw new ServiceRequestException("The response received from the service didn't contain valid XML.");
     }
 
@@ -463,9 +446,7 @@ public abstract class ServiceRequestBase<T> {
     } catch (IOException e) {
       throw new ServiceRequestException(String.format("The request failed. %s", e.getMessage()), e);
     } finally { // close the underlying response
-      if (response != null) {
-        response.close();
-      }
+      response.close();
     }
   }
 
@@ -505,7 +486,7 @@ public abstract class ServiceRequestBase<T> {
    * Reads any preamble data not part of the core response.
    *
    * @param ewsXmlReader The EwsServiceXmlReader.
-   * @throws Exception
+   * @throws Exception on error
    */
   protected void readPreamble(EwsServiceXmlReader ewsXmlReader)
       throws Exception {
@@ -538,13 +519,13 @@ public abstract class ServiceRequestBase<T> {
   /**
    * Processes the web exception.
    *
-   * @param webException The web exception.
-   * @param req          http Request object used to send the http request.
-   * @throws Exception
+   * @param webException the web exception
+   * @param req HTTP Request object used to send the http request
+   * @throws Exception on error
    */
   protected void processWebException(Exception webException, HttpWebRequest req)
       throws Exception {
-    SoapFaultDetails soapFaultDetails = null;
+    SoapFaultDetails soapFaultDetails;
     if (null != req) {
       this.getService().processHttpResponseHeaders(
           TraceFlags.EwsResponseHttpHeaders, req);
@@ -718,8 +699,9 @@ public abstract class ServiceRequestBase<T> {
    * Validates request parameters, and emits the request to the server.
    *
    * @return The response returned by the server.
+   * @throws Exception on error
    */
-  protected HttpWebRequest validateAndEmitRequest() throws ServiceLocalException, Exception {
+  protected HttpWebRequest validateAndEmitRequest() throws Exception {
     this.validate();
 
     HttpWebRequest request = this.buildEwsHttpWebRequest();
@@ -745,10 +727,10 @@ public abstract class ServiceRequestBase<T> {
   }
 
   /**
-   * <summary> Builds the HttpWebRequest object for current service request
-   * with exception handling.
+   * Builds the HttpWebRequest object for current service request with exception handling.
    *
    * @return An HttpWebRequest instance
+   * @throws Exception on error
    */
   protected HttpWebRequest buildEwsHttpWebRequest() throws Exception {
     try {
@@ -784,6 +766,7 @@ public abstract class ServiceRequestBase<T> {
    *
    * @param request The specified HttpWebRequest
    * @return An HttpWebResponse instance
+   * @throws Exception on error
    */
   protected HttpWebRequest getEwsHttpWebResponse(HttpWebRequest request) throws Exception {
     try {

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/SimpleServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/SimpleServiceRequestBase.java
@@ -24,9 +24,7 @@
 package microsoft.exchange.webservices.data.core.request;
 
 import microsoft.exchange.webservices.data.core.ExchangeService;
-import microsoft.exchange.webservices.data.core.WebAsyncCallStateAnchor;
 import microsoft.exchange.webservices.data.enumeration.TraceFlags;
-import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.ServiceRequestException;
 import microsoft.exchange.webservices.data.misc.AsyncCallback;
 import microsoft.exchange.webservices.data.misc.AsyncExecutor;
@@ -45,8 +43,6 @@ import java.util.concurrent.Future;
  */
 public abstract class SimpleServiceRequestBase<T> extends ServiceRequestBase<T> {
 
-  private static final Log log = LogFactory.getLog(SimpleServiceRequestBase.class);
-
   /**
    * Initializes a new instance of the SimpleServiceRequestBase class.
    */
@@ -58,10 +54,10 @@ public abstract class SimpleServiceRequestBase<T> extends ServiceRequestBase<T> 
   /**
    * Executes this request.
    *
-   * @throws Exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException
+   * @return response object
+   * @throws Exception on error
    */
-  protected T internalExecute() throws ServiceLocalException, Exception {
+  protected T internalExecute() throws Exception {
     HttpWebRequest response = null;
 
     try {
@@ -85,7 +81,8 @@ public abstract class SimpleServiceRequestBase<T> extends ServiceRequestBase<T> 
    * Ends executing this async request.
    *
    * @param asyncResult The async result
-   * @return Service response object.
+   * @return Service response object
+   * @throws Exception on error
    */
   protected T endInternalExecute(IAsyncResult asyncResult) throws Exception {
     HttpWebRequest response = (HttpWebRequest) asyncResult.get();
@@ -96,29 +93,19 @@ public abstract class SimpleServiceRequestBase<T> extends ServiceRequestBase<T> 
    * Begins executing this async request.
    *
    * @param callback The AsyncCallback delegate.
-   * @param state    An object that contains state information for this request.
    * @return An IAsyncResult that references the asynchronous request.
+   * @throws Exception on error
    */
-  public AsyncRequestResult beginExecute(AsyncCallback callback, Object state) throws Exception {
+  public AsyncRequestResult beginExecute(AsyncCallback callback) throws Exception {
     this.validate();
 
     HttpWebRequest request = this.buildEwsHttpWebRequest();
-
-    WebAsyncCallStateAnchor wrappedState = new WebAsyncCallStateAnchor(
-        this, request, callback /* user callback */, state /*user state*/);
-
     AsyncExecutor es = new AsyncExecutor();
     Callable<?> cl = new CallableMethod(request);
     Future<?> task = es.submit(cl, callback);
     es.shutdown();
-    AsyncRequestResult ft = new AsyncRequestResult(this, request, task, null);
 
-    // ct.setAsyncRequest();
-    // webAsyncResult =
-    // request.beginGetResponse(SimpleServiceRequestBase.webRequestAsyncCallback(webAsyncResult),
-    // wrappedState);
-    return ft;
-    // return new AsyncRequestResult(this, request, webAsyncResult, state /*
-    // user state */);
+    return new AsyncRequestResult(this, request, task, null);
   }
+
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/SubscribeRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/SubscribeRequest.java
@@ -148,8 +148,8 @@ abstract class SubscribeRequest<TSubscription extends SubscriptionBase> extends
    * Internal method to write XML elements.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   protected abstract void internalWriteElementsToXml(
       EwsServiceXmlWriter writer) throws XMLStreamException, ServiceXmlSerializationException;

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/SubscribeToPullNotificationsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/SubscribeToPullNotificationsRequest.java
@@ -129,8 +129,8 @@ public class SubscribeToPullNotificationsRequest extends
    * Reads response elements from XML.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException                                  the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected void internalWriteElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/UnsubscribeRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/UnsubscribeRequest.java
@@ -127,8 +127,8 @@ public class UnsubscribeRequest extends MultiResponseServiceRequest<ServiceRespo
    * Writes XML elements.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/UpdateDelegateRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/UpdateDelegateRequest.java
@@ -64,7 +64,7 @@ public class UpdateDelegateRequest extends
   }
 
   /**
-   * Validate request..
+   * Validate request.
    *
    * @throws Exception the exception
    */
@@ -144,8 +144,7 @@ public class UpdateDelegateRequest extends
   }
 
   /**
-   * Gets the meeting request delivery scope. <value>The meeting
-   * request delivery scope.</value>
+   * Gets the meeting request delivery scope.
    *
    * @return the meeting request delivery scope
    */
@@ -164,7 +163,7 @@ public class UpdateDelegateRequest extends
   }
 
   /**
-   * Gets the delegate users. <value>The delegate users.</value>
+   * Gets the delegate users.
    *
    * @return the delegate users
    */

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/UpdateInboxRulesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/UpdateInboxRulesRequest.java
@@ -32,7 +32,6 @@ import microsoft.exchange.webservices.data.core.response.UpdateInboxRulesRespons
 import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.ServiceResult;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
-import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.UpdateInboxRulesException;
 import microsoft.exchange.webservices.data.property.complex.RuleOperation;
 
@@ -161,11 +160,9 @@ public final class UpdateInboxRulesRequest extends SimpleServiceRequestBase<Upda
    * Executes this request.
    *
    * @return Service response.
-   * @throws Exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException
+   * @throws Exception on error
    */
-  public UpdateInboxRulesResponse execute()
-      throws ServiceLocalException, Exception {
+  public UpdateInboxRulesResponse execute() throws Exception {
     UpdateInboxRulesResponse serviceResponse = internalExecute();
     if (serviceResponse.getResult() == ServiceResult.Error) {
       throw new UpdateInboxRulesException(serviceResponse,

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/UpdateUserConfigurationRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/UpdateUserConfigurationRequest.java
@@ -31,7 +31,6 @@ import microsoft.exchange.webservices.data.core.response.ServiceResponse;
 import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.ServiceErrorHandling;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
-import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.misc.UserConfiguration;
 
 /**
@@ -48,11 +47,10 @@ public class UpdateUserConfigurationRequest extends
   /**
    * Validate request.
    *
-   * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
-   * @throws Exception                                                 the exception
+   * @throws Exception the exception
    */
   @Override
-  protected void validate() throws ServiceLocalException, Exception {
+  protected void validate() throws Exception {
     super.validate();
     EwsUtilities.validateParam(this.userConfiguration, "userConfiguration");
   }
@@ -137,7 +135,7 @@ public class UpdateUserConfigurationRequest extends
    * Initializes a new instance of the class.
    *
    * @param service the service
-   * @throws Exception
+   * @throws Exception on error
    */
   public UpdateUserConfigurationRequest(ExchangeService service)
       throws Exception {
@@ -145,8 +143,7 @@ public class UpdateUserConfigurationRequest extends
   }
 
   /**
-   * Gets the user configuration. <value>The user
-   * configuration.</value>
+   * Gets the user configuration.
    *
    * @return the user configuration
    */

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/FindItemResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/FindItemResponse.java
@@ -155,12 +155,12 @@ public final class FindItemResponse
   /**
    * Read item from XML.
    *
-   * @param reader          The reader
-   * @param propertySet     The property set
-   * @param destinationList The list in which to add the read item.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws Exception                           the exception
+   * @param reader the reader
+   * @param propertySet the property set
+   * @param destinationList the list in which to add the read item
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
+   * @throws Exception the exception
    */
   private void internalReadItemsFromXml(EwsServiceXmlReader reader,
       PropertySet propertySet, List<TItem> destinationList)

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/GetInboxRulesResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/GetInboxRulesResponse.java
@@ -38,8 +38,7 @@ public final class GetInboxRulesResponse extends ServiceResponse {
   private RuleCollection ruleCollection;
 
   /**
-   * Initializes a new instance of the
-   * <see cref="GetInboxRulesResponse"/> class.
+   * Initializes a new instance of the {@link GetInboxRulesResponse} class.
    */
   public GetInboxRulesResponse() {
     super();

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/GetServerTimeZonesResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/GetServerTimeZonesResponse.java
@@ -26,8 +26,6 @@ package microsoft.exchange.webservices.data.core.response;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
-import microsoft.exchange.webservices.data.exception.ServiceLocalException;
-import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
 import microsoft.exchange.webservices.data.property.complex.time.TimeZoneDefinition;
 
 import javax.xml.stream.XMLStreamException;
@@ -57,17 +55,10 @@ public class GetServerTimeZonesResponse extends ServiceResponse {
    * Reads response elements from XML.
    *
    * @param reader the reader
-   * @throws ServiceXmlDeserializationException                        the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException                       the xML stream exception
-   * @throws InstantiationException                                    the instantiation exception
-   * @throws IllegalAccessException                                    the illegal access exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
-   * @throws Exception                                                 the exception
+   * @throws Exception the exception
    */
   @Override
-  protected void readElementsFromXml(EwsServiceXmlReader reader)
-      throws ServiceXmlDeserializationException, XMLStreamException,
-      InstantiationException, IllegalAccessException, ServiceLocalException, Exception {
+  protected void readElementsFromXml(EwsServiceXmlReader reader) throws Exception {
     super.readElementsFromXml(reader);
 
     reader.readStartElement(XmlNamespace.Messages,

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/GetUserConfigurationResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/GetUserConfigurationResponse.java
@@ -25,11 +25,7 @@ package microsoft.exchange.webservices.data.core.response;
 
 import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.EwsUtilities;
-import microsoft.exchange.webservices.data.exception.ServiceLocalException;
-import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
 import microsoft.exchange.webservices.data.misc.UserConfiguration;
-
-import javax.xml.stream.XMLStreamException;
 
 /**
  * Represents a response to a GetUserConfiguration request.
@@ -58,17 +54,10 @@ public final class GetUserConfigurationResponse extends ServiceResponse {
    * Reads response elements from XML.
    *
    * @param reader the reader
-   * @throws ServiceXmlDeserializationException                        the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException                       the xML stream exception
-   * @throws InstantiationException                                    the instantiation exception
-   * @throws IllegalAccessException                                    the illegal access exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
-   * @throws Exception                                                 the exception
+   * @throws Exception the exception
    */
   @Override
-  protected void readElementsFromXml(EwsServiceXmlReader reader)
-      throws ServiceXmlDeserializationException, XMLStreamException,
-      InstantiationException, IllegalAccessException, ServiceLocalException, Exception {
+  protected void readElementsFromXml(EwsServiceXmlReader reader) throws Exception {
     super.readElementsFromXml(reader);
     this.userConfiguration.loadFromXml(reader);
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/GetUserOofSettingsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/GetUserOofSettingsResponse.java
@@ -43,7 +43,7 @@ public class GetUserOofSettingsResponse extends ServiceResponse {
   }
 
   /**
-   * Gets  the OOF settings. <value>The oof settings.</value>
+   * Gets  the OOF settings.
    *
    * @return the oof settings
    */

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/ServiceResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/ServiceResponse.java
@@ -30,9 +30,7 @@ import microsoft.exchange.webservices.data.core.service.schema.ServiceObjectSche
 import microsoft.exchange.webservices.data.enumeration.ServiceError;
 import microsoft.exchange.webservices.data.enumeration.ServiceResult;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
-import microsoft.exchange.webservices.data.exception.ServiceLocalException;
 import microsoft.exchange.webservices.data.exception.ServiceResponseException;
-import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
 import microsoft.exchange.webservices.data.misc.SoapFaultDetails;
 import microsoft.exchange.webservices.data.property.definition.ExtendedPropertyDefinition;
 import microsoft.exchange.webservices.data.property.definition.IndexedPropertyDefinition;
@@ -235,17 +233,10 @@ public class ServiceResponse {
   /**
    * Reads response elements from XML.
    *
-   * @param reader The reader.
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws InstantiationException              the instantiation exception
-   * @throws IllegalAccessException              the illegal access exception
-   * @throws ServiceLocalException               the service local exception
-   * @throws Exception                           the exception
+   * @param reader the reader
+   * @throws Exception the exception
    */
-  protected void readElementsFromXml(EwsServiceXmlReader reader)
-      throws ServiceXmlDeserializationException, XMLStreamException,
-      InstantiationException, IllegalAccessException, ServiceLocalException, Exception {
+  protected void readElementsFromXml(EwsServiceXmlReader reader) throws Exception {
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/SubscribeResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/SubscribeResponse.java
@@ -25,11 +25,7 @@ package microsoft.exchange.webservices.data.core.response;
 
 import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.EwsUtilities;
-import microsoft.exchange.webservices.data.exception.ServiceLocalException;
-import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
 import microsoft.exchange.webservices.data.notification.SubscriptionBase;
-
-import javax.xml.stream.XMLStreamException;
 
 /**
  * Represents the base response class to subscription creation operations.
@@ -58,18 +54,11 @@ public final class SubscribeResponse<TSubscription extends SubscriptionBase> ext
   /**
    * Reads response elements from XML.
    *
-   * @param reader The reader.
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws InstantiationException              the instantiation exception
-   * @throws IllegalAccessException              the illegal access exception
-   * @throws ServiceLocalException               the service local exception
-   * @throws Exception                           the exception
+   * @param reader the reader
+   * @throws Exception the exception
    */
   @Override
-  protected void readElementsFromXml(EwsServiceXmlReader reader)
-      throws ServiceXmlDeserializationException, XMLStreamException,
-      InstantiationException, IllegalAccessException, ServiceLocalException, Exception {
+  protected void readElementsFromXml(EwsServiceXmlReader reader) throws Exception {
     super.readElementsFromXml(reader);
     this.subscription.loadFromXml(reader);
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/SyncFolderHierarchyResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/SyncFolderHierarchyResponse.java
@@ -64,9 +64,8 @@ public final class SyncFolderHierarchyResponse extends
   }
 
   /**
-   * Gets a value indicating whether this request returns full or summary
-   * property. <value> <c>true</c> if summary property only; otherwise,
-   * <c>false</c>. </value>
+   * Gets a value indicating whether this request returns full or summary property.
+   * "true" if summary property only; otherwise, "false".
    *
    * @return the summary property only
    */

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/SyncFolderItemsResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/SyncFolderItemsResponse.java
@@ -64,9 +64,8 @@ public final class SyncFolderItemsResponse extends
   }
 
   /**
-   * Gets a value indicating whether this request returns full or summary
-   * property. <value> <c>true</c> if summary property only; otherwise,
-   * <c>false</c>. </value>
+   * Gets a value indicating whether this request returns full or summary property.
+   * "true" if summary property only; otherwise, "false".
    *
    * @return the summary property only
    */
@@ -74,4 +73,5 @@ public final class SyncFolderItemsResponse extends
   protected boolean getSummaryPropertiesOnly() {
     return true;
   }
+
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/response/UpdateItemResponse.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/response/UpdateItemResponse.java
@@ -71,16 +71,10 @@ public final class UpdateItemResponse extends ServiceResponse implements
    * Reads response elements from XML.
    *
    * @param reader the reader
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws InstantiationException              the instantiation exception
-   * @throws IllegalAccessException              the illegal access exception
-   * @throws Exception                           the exception
+   * @throws Exception the exception
    */
   @Override
-  protected void readElementsFromXml(EwsServiceXmlReader reader)
-      throws ServiceXmlDeserializationException, XMLStreamException,
-      InstantiationException, IllegalAccessException, Exception {
+  protected void readElementsFromXml(EwsServiceXmlReader reader) throws Exception {
     super.readElementsFromXml(reader);
 
     reader.readServiceObjectsCollectionFromXml(XmlElementNames.Items, this,

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/folder/Folder.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/folder/Folder.java
@@ -72,9 +72,9 @@ public class Folder extends ServiceObject {
   private static final Log LOG = LogFactory.getLog(Folder.class);
 
   /**
-   * Initializes an unsaved local instance of <see cref="Folder"/>.
+   * Initializes an unsaved local instance of {@link Folder}.
    *
-   * @param service EWS service to which this object belongs.
+   * @param service EWS service to which this object belongs
    * @throws Exception the exception
    */
   public Folder(ExchangeService service) throws Exception {

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/item/Contact.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/item/Contact.java
@@ -71,8 +71,8 @@ public class Contact extends Item {
   private final String ContactPictureName = "ContactPicture.jpg";
 
   /**
-   * Initializes an unsaved local instance of <see cref="Contact"/>. To bind
-   * to an existing contact, use Contact.Bind() instead.
+   * Initializes an unsaved local instance of {@link Contact}.
+   * To bind to an existing contact, use Contact.Bind() instead.
    *
    * @param service the service
    * @throws Exception the exception
@@ -82,7 +82,7 @@ public class Contact extends Item {
   }
 
   /**
-   * Initializes a new instance of the <see cref="Contact"/> class.
+   * Initializes a new instance of the {@link Contact} class.
    *
    * @param parentAttachment the parent attachment
    * @throws Exception the exception

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/response/AcceptMeetingInvitationMessage.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/response/AcceptMeetingInvitationMessage.java
@@ -60,10 +60,10 @@ public final class AcceptMeetingInvitationMessage extends
    * returns null or empty, the XML element name associated with this
    * type is determined by the EwsObjectDefinition attribute that
    * decorates the type, if present.
-   * <p/>
+   * <p>
    * Item and folder classes that can be returned by EWS MUST rely on
-   * the EwsObjectDefinition attribute for XML element name
-   * determination.
+   * the EwsObjectDefinition attribute for XML element name determination.
+   * </p>
    */
   @Override public String getXmlElementName() {
     // getXmlElementOverride is pvt and getXmlElementName returns

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/schema/AppointmentSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/schema/AppointmentSchema.java
@@ -831,9 +831,10 @@ public class AppointmentSchema extends ItemSchema {
 
   /**
    * Registers property.
-   * <p/>
+   * <p>
    * IMPORTANT NOTE: PROPERTIES MUST BE REGISTERED IN SCHEMA ORDER (i.e. the
    * same order as they are defined in types.xsd)
+   * </p>
    */
   @Override
   protected void registerProperties() {

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/schema/ContactGroupSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/schema/ContactGroupSchema.java
@@ -101,9 +101,10 @@ public class ContactGroupSchema extends ItemSchema {
 
   /**
    * Registers property.
-   * <p/>
+   * <p>
    * IMPORTANT NOTE: PROPERTIES MUST BE REGISTERED IN SCHEMA ORDER (i.e. the
    * same order as they are defined in types.xsd)
+   * </p>
    */
   @Override
   protected void registerProperties() {

--- a/src/main/java/microsoft/exchange/webservices/data/core/service/schema/ItemSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/schema/ItemSchema.java
@@ -694,9 +694,10 @@ public class ItemSchema extends ServiceObjectSchema {
 
   /**
    * Registers property.
-   * <p/>
+   * <p>
    * IMPORTANT NOTE: PROPERTIES MUST BE REGISTERED IN SCHEMA ORDER (i.e. the
    * same order as they are defined in types.xsd)
+   * </p>
    */
   @Override
   protected void registerProperties() {

--- a/src/main/java/microsoft/exchange/webservices/data/credential/ExchangeCredentials.java
+++ b/src/main/java/microsoft/exchange/webservices/data/credential/ExchangeCredentials.java
@@ -59,7 +59,7 @@ public abstract class ExchangeCredentials {
 
 
   /**
-   * Return the url without wssecruity address.
+   * Return the url without ws-security address.
    *
    * @param url The url
    * @return The absolute uri base.
@@ -98,8 +98,8 @@ public abstract class ExchangeCredentials {
   /**
    * Emit any extra necessary namespace aliases for the SOAP:header block.
    *
-   * @param writer The writer.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
    */
   public void emitExtraSoapHeaderNamespaceAliases(XMLStreamWriter writer)
       throws XMLStreamException {
@@ -111,9 +111,9 @@ public abstract class ExchangeCredentials {
    * authentication schemes that rely on WS-Security, or for endpoints
    * requiring WS-Addressing.
    *
-   * @param writer        The writer.
-   * @param webMethodName The Web method being called.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @param writer the writer
+   * @param webMethodName the Web method being called
+   * @throws XMLStreamException the XML stream exception
    */
   public void serializeExtraSoapHeaders(XMLStreamWriter writer, String webMethodName) throws XMLStreamException {
     // do nothing by default.
@@ -148,16 +148,14 @@ public abstract class ExchangeCredentials {
 
 
   /**
-   * Serialize SOAP headers used for authentication schemes that rely on
-   * WS-Security.
+   * Serialize SOAP headers used for authentication schemes that rely on WS-Security.
    *
-   * @param writer The writer.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
    */
   public void serializeWSSecurityHeaders(XMLStreamWriter writer)
       throws XMLStreamException {
     // do nothing by default.
   }
-
 
 }

--- a/src/main/java/microsoft/exchange/webservices/data/credential/WSSecurityBasedCredentials.java
+++ b/src/main/java/microsoft/exchange/webservices/data/credential/WSSecurityBasedCredentials.java
@@ -146,8 +146,8 @@ public abstract class WSSecurityBasedCredentials extends ExchangeCredentials {
   /**
    * Emit the extra namespace aliases used for WS-Security and WS-Addressing.
    *
-   * @param writer The writer.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
    */
   @Override public void emitExtraSoapHeaderNamespaceAliases(XMLStreamWriter writer)
       throws XMLStreamException {
@@ -166,9 +166,9 @@ public abstract class WSSecurityBasedCredentials extends ExchangeCredentials {
   /**
    * Serialize the WS-Security and WS-Addressing SOAP headers.
    *
-   * @param writer        The writer.
-   * @param webMethodName The Web method being called.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @param writer the writer
+   * @param webMethodName the Web method being called
+   * @throws XMLStreamException the XML stream exception
    */
   @Override public void serializeExtraSoapHeaders(XMLStreamWriter writer, String webMethodName) throws XMLStreamException {
     this.serializeWSAddressingHeaders(writer, webMethodName);
@@ -176,12 +176,11 @@ public abstract class WSSecurityBasedCredentials extends ExchangeCredentials {
   }
 
   /**
-   * Creates the WS-Addressing headers necessary to send with an outgoing
-   * request.
+   * Creates the WS-Addressing headers necessary to send with an outgoing request.
    *
-   * @param xmlWriter     The XML writer to serialize the headers to.
-   * @param webMethodName The Web method being called.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @param xmlWriter the XML writer to serialize the headers to
+   * @param webMethodName the Web method being called
+   * @throws XMLStreamException the XML stream exception
    */
   private void serializeWSAddressingHeaders(XMLStreamWriter xmlWriter,
       String webMethodName) throws XMLStreamException {
@@ -203,11 +202,10 @@ public abstract class WSSecurityBasedCredentials extends ExchangeCredentials {
   }
 
   /**
-   * Creates the WS-Security header necessary to send with an outgoing
-   * request.
+   * Creates the WS-Security header necessary to send with an outgoing request.
    *
-   * @param xmlWriter The XML writer to serialize the headers to.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @param xmlWriter The XML writer to serialize the headers to
+   * @throws XMLStreamException the XML stream exception
    */
   @Override public void serializeWSSecurityHeaders(XMLStreamWriter xmlWriter)
       throws XMLStreamException {

--- a/src/main/java/microsoft/exchange/webservices/data/misc/HangingTraceStream.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/HangingTraceStream.java
@@ -143,9 +143,9 @@ public class HangingTraceStream extends InputStream {
   }
 
   /**
-   * sets the response copy
+   * Sets the response copy.
    *
-   * @param responsecopy a copy of response
+   * @param responseCopy a copy of response
    */
   public void setResponseCopy(ByteArrayOutputStream responseCopy) {
     this.responseCopy = responseCopy;

--- a/src/main/java/microsoft/exchange/webservices/data/misc/MobilePhone.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/MobilePhone.java
@@ -83,9 +83,9 @@ public final class MobilePhone implements ISelfValidate {
 
 
   /**
-   * Validates this instance.//>!(contentType == null || contentType.isEmpty()
+   * Validates this instance.
    *
-   * @throws microsoft.exchange.webservices.data.exception.ServiceValidationException
+   * @throws ServiceValidationException on validation error
    */
   public void validate() throws ServiceValidationException {
     if (this.getPhoneNumber() == null || this.getPhoneNumber().isEmpty()) {

--- a/src/main/java/microsoft/exchange/webservices/data/misc/SoapFaultDetails.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/SoapFaultDetails.java
@@ -138,13 +138,9 @@ public class SoapFaultDetails {
    * Parses the detail node.
    *
    * @param reader the reader
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws Exception                           the exception
+   * @throws Exception the exception
    */
-  private void parseDetailNode(EwsXmlReader reader)
-      throws ServiceXmlDeserializationException, XMLStreamException,
-      Exception, Exception {
+  private void parseDetailNode(EwsXmlReader reader) throws Exception {
     do {
       reader.read();
       if (reader.getNodeType().equals(

--- a/src/main/java/microsoft/exchange/webservices/data/misc/UserConfiguration.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/UserConfiguration.java
@@ -144,11 +144,11 @@ public class UserConfiguration {
   /**
    * Writes a byte array to Xml.
    *
-   * @param writer         The writer.
-   * @param byteArray      Byte array to write.
-   * @param xmlElementName Name of the Xml element.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer         the writer
+   * @param byteArray      byte array to write
+   * @param xmlElementName name of the Xml element
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   private static void writeByteArrayToXml(EwsServiceXmlWriter writer,
       byte[] byteArray, String xmlElementName) throws XMLStreamException, ServiceXmlSerializationException {
@@ -551,9 +551,9 @@ public class UserConfiguration {
   /**
    * Writes the XmlData property to Xml.
    *
-   * @param writer The writer.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   private void writeXmlDataToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {
@@ -566,9 +566,9 @@ public class UserConfiguration {
   /**
    * Writes the BinaryData property to Xml.
    *
-   * @param writer The writer.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   private void writeBinaryDataToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/misc/availability/LegacyAvailabilityTimeZoneTime.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/availability/LegacyAvailabilityTimeZoneTime.java
@@ -157,8 +157,8 @@ final class LegacyAvailabilityTimeZoneTime extends ComplexProperty {
    * Writes the elements to XML.
    *
    * @param writer the writer
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/misc/availability/OofReply.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/availability/OofReply.java
@@ -52,7 +52,7 @@ public final class OofReply {
    *
    * @param writer         the writer
    * @param xmlElementName the xml element name
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws XMLStreamException the XML stream exception
    */
   public static void writeEmptyReplyToXml(EwsServiceXmlWriter writer, String xmlElementName) throws XMLStreamException {
     writer.writeStartElement(XmlNamespace.Types, xmlElementName);
@@ -124,8 +124,8 @@ public final class OofReply {
    *
    * @param writer         the writer
    * @param xmlElementName the xml element name
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeToXml(EwsServiceXmlWriter writer, String xmlElementName)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/misc/availability/TimeWindow.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/availability/TimeWindow.java
@@ -130,8 +130,8 @@ public class TimeWindow implements ISelfValidate {
    * @param xmlElementName the xml element name
    * @param startTime      the start time
    * @param endTime        the end time
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   private static void writeToXml(EwsServiceXmlWriter writer,
       String xmlElementName, Object startTime, Object endTime)
@@ -152,8 +152,8 @@ public class TimeWindow implements ISelfValidate {
    *
    * @param writer         the writer
    * @param xmlElementName the xml element name
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   protected void writeToXmlUnscopedDatesOnly(EwsServiceXmlWriter writer,
       String xmlElementName) throws XMLStreamException, ServiceXmlSerializationException {
@@ -171,13 +171,12 @@ public class TimeWindow implements ISelfValidate {
    *
    * @param writer         the writer
    * @param xmlElementName the xml element name
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeToXml(EwsServiceXmlWriter writer, String xmlElementName)
       throws XMLStreamException, ServiceXmlSerializationException {
-    TimeWindow.writeToXml(writer, xmlElementName, this.startTime,
-        this.endTime);
+    TimeWindow.writeToXml(writer, xmlElementName, startTime, endTime);
   }
 
   /**
@@ -193,10 +192,5 @@ public class TimeWindow implements ISelfValidate {
    * Validates this instance.
    */
   public void validate() {
-                /*
-		 * if (this.startTime >= this.endTime) { throw new
-		 * ArgumentException(Strings
-		 * .TimeWindowStartTimeMustBeGreaterThanEndTime); }
-		 */
   }
 }

--- a/src/main/java/microsoft/exchange/webservices/data/misc/id/AlternateIdBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/misc/id/AlternateIdBase.java
@@ -111,8 +111,8 @@ public abstract class AlternateIdBase implements ISelfValidate {
    * Writes to XML.
    *
    * @param writer the writer
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   public void writeToXml(EwsServiceXmlWriter writer)
       throws ServiceXmlSerializationException, XMLStreamException {

--- a/src/main/java/microsoft/exchange/webservices/data/notification/NotificationEvent.java
+++ b/src/main/java/microsoft/exchange/webservices/data/notification/NotificationEvent.java
@@ -26,7 +26,6 @@ package microsoft.exchange.webservices.data.notification;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.enumeration.EventType;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
-import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
 import microsoft.exchange.webservices.data.property.complex.FolderId;
 
 import javax.xml.stream.XMLStreamException;
@@ -76,15 +75,9 @@ public abstract class NotificationEvent {
    * Load from XML.
    *
    * @param reader the reader
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws InstantiationException              the instantiation exception
-   * @throws IllegalAccessException              the illegal access exception
-   * @throws Exception                           the exception
+   * @throws Exception the exception
    */
-  protected void internalLoadFromXml(EwsServiceXmlReader reader)
-      throws ServiceXmlDeserializationException, XMLStreamException,
-      InstantiationException, IllegalAccessException, Exception {
+  protected void internalLoadFromXml(EwsServiceXmlReader reader) throws Exception {
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/DelegatePermissions.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/DelegatePermissions.java
@@ -274,8 +274,9 @@ public final class DelegatePermissions extends ComplexProperty {
   /**
    * Write permission to Xml.
    *
-   * @param writer         The writer.
-   * @param xmlElementName The element name.
+   * @param writer         the writer
+   * @param xmlElementName the element name
+   * @throws XMLStreamException the XML stream exception
    */
   private void writePermissionToXml(
       EwsServiceXmlWriter writer,

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/DeleteRuleOperation.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/DeleteRuleOperation.java
@@ -76,7 +76,8 @@ public final class DeleteRuleOperation extends RuleOperation {
   /**
    * Writes elements to XML.
    *
-   * @param writer The writer.
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/DictionaryEntryProperty.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/DictionaryEntryProperty.java
@@ -117,12 +117,12 @@ public abstract class DictionaryEntryProperty<TKey> extends ComplexProperty {
   /**
    * Writes the set update to XML.
    *
-   * @param writer                        The writer.
-   * @param ewsObject                     The ews object.
-   * @param ownerDictionaryXmlElementName Name of the owner dictionary XML element.
-   * @return True if update XML was written.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer                        the writer
+   * @param ewsObject                     the ews object
+   * @param ownerDictionaryXmlElementName name of the owner dictionary XML element
+   * @return true if update XML was written
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   protected boolean writeSetUpdateToXml(EwsServiceXmlWriter writer,
       ServiceObject ewsObject, String ownerDictionaryXmlElementName)
@@ -133,11 +133,11 @@ public abstract class DictionaryEntryProperty<TKey> extends ComplexProperty {
   /**
    * Writes the delete update to XML.
    *
-   * @param writer    The writer.
-   * @param ewsObject The ews object.
-   * @return True if update XML was written.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer    the writer
+   * @param ewsObject the ews object
+   * @return true if update XML was written
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   protected boolean writeDeleteUpdateToXml(EwsServiceXmlWriter writer,
       ServiceObject ewsObject) throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/ExtendedProperty.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/ExtendedProperty.java
@@ -112,8 +112,8 @@ public final class ExtendedProperty extends ComplexProperty {
    * Writes elements to XML.
    *
    * @param writer the writer
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/ExtendedPropertyCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/ExtendedPropertyCollection.java
@@ -259,11 +259,11 @@ public final class ExtendedPropertyCollection extends ComplexPropertyCollection<
   /**
    * Writes the deletion update to XML.
    *
-   * @param writer    The writer.
-   * @param ewsObject The ews object.
-   * @return True if property generated serialization.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer    the writer
+   * @param ewsObject the ews object
+   * @return true if property generated serialization
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   public boolean writeDeleteUpdateToXml(EwsServiceXmlWriter writer,

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/GroupMemberCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/GroupMemberCollection.java
@@ -387,8 +387,8 @@ public final class GroupMemberCollection extends ComplexPropertyCollection<Group
    * Delete the whole members collection.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   private void writeDeleteMembersCollectionToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {
@@ -403,8 +403,8 @@ public final class GroupMemberCollection extends ComplexPropertyCollection<Group
    *
    * @param writer  the writer
    * @param members the members
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   private void writeDeleteMembersToXml(EwsServiceXmlWriter writer,
       List<GroupMember> members) throws XMLStreamException,

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/ImAddressEntry.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/ImAddressEntry.java
@@ -86,8 +86,8 @@ public final class ImAddressEntry extends DictionaryEntryProperty<ImAddressKey> 
    * Reads the text value from XML.
    *
    * @param reader accepts EwsServiceXmlReader
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
    */
   @Override
   public void readTextValueFromXml(EwsServiceXmlReader reader)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/InternetMessageHeader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/InternetMessageHeader.java
@@ -67,8 +67,8 @@ public final class InternetMessageHeader extends ComplexProperty {
    * Reads the text value from XML.
    *
    * @param reader the reader
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException  the service xml deserialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
    */
   public void readTextValueFromXml(EwsServiceXmlReader reader)
       throws XMLStreamException, ServiceXmlDeserializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/Mailbox.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/Mailbox.java
@@ -161,8 +161,8 @@ public class Mailbox extends ComplexProperty implements ISearchStringProvider {
    * Writes elements to XML.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeElementsToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/MessageBody.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/MessageBody.java
@@ -119,9 +119,9 @@ public final class MessageBody extends ComplexProperty {
   /**
    * Reads text value from XML.
    *
-   * @param reader The reader.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException  the service xml deserialization exception
+   * @param reader the reader
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
    */
   @Override
   public void readTextValueFromXml(EwsServiceXmlReader reader)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/MimeContent.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/MimeContent.java
@@ -82,8 +82,8 @@ public final class MimeContent extends ComplexProperty {
    * Reads text value from XML.
    *
    * @param reader the reader
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException  the service xml deserialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
    */
   @Override
   public void readTextValueFromXml(EwsServiceXmlReader reader)
@@ -108,7 +108,7 @@ public final class MimeContent extends ComplexProperty {
    * Writes elements to XML.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws XMLStreamException the XML stream exception
    */
   public void writeElementsToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/PhysicalAddressEntry.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/PhysicalAddressEntry.java
@@ -206,8 +206,8 @@ public final class PhysicalAddressEntry extends DictionaryEntryProperty<Physical
    * Writes elements to XML.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)
@@ -225,9 +225,9 @@ public final class PhysicalAddressEntry extends DictionaryEntryProperty<Physical
    * @param writer                        the writer
    * @param ewsObject                     the ews object
    * @param ownerDictionaryXmlElementName the owner dictionary xml element name
-   * @return True if update XML was written.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @return true if update XML was written
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected boolean writeSetUpdateToXml(EwsServiceXmlWriter writer,
@@ -283,9 +283,9 @@ public final class PhysicalAddressEntry extends DictionaryEntryProperty<Physical
    *
    * @param writer    the writer
    * @param ewsObject the ews object
-   * @return True if update XML was written.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @return true if update XML was written
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected boolean writeDeleteUpdateToXml(EwsServiceXmlWriter writer,
@@ -314,8 +314,8 @@ public final class PhysicalAddressEntry extends DictionaryEntryProperty<Physical
    * @param writer              the writer
    * @param ewsObject           the ews object
    * @param fieldXmlElementName the field xml element name
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   private void internalWriteDeleteFieldToXml(EwsServiceXmlWriter writer,
       ServiceObject ewsObject, String fieldXmlElementName)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/RulePredicateDateRange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/RulePredicateDateRange.java
@@ -109,7 +109,8 @@ public final class RulePredicateDateRange extends ComplexProperty {
   /**
    * Writes elements to XML.
    *
-   * @param writer The writer.
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/RulePredicateSizeRange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/RulePredicateSizeRange.java
@@ -111,7 +111,8 @@ public final class RulePredicateSizeRange extends ComplexProperty {
   /**
    * Writes elements to XML.
    *
-   * @param writer The writer.
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/StringList.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/StringList.java
@@ -80,8 +80,8 @@ public class StringList extends ComplexProperty implements Iterable<String> {
    *
    * @param reader accepts EwsServiceXmlReader
    * @return True if element was read
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
    */
   @Override
   public boolean tryReadElementFromXml(EwsServiceXmlReader reader)
@@ -105,8 +105,8 @@ public class StringList extends ComplexProperty implements Iterable<String> {
    * Writes elements to XML.
    *
    * @param writer accepts EwsServiceXmlWriter
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/TimeChangeRecurrence.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/TimeChangeRecurrence.java
@@ -144,8 +144,8 @@ final class TimeChangeRecurrence extends ComplexProperty {
    * Writes elements to XML.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeElementsToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/UniqueBody.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/UniqueBody.java
@@ -85,8 +85,8 @@ public final class UniqueBody extends ComplexProperty {
    * Reads attribute from XML.
    *
    * @param reader the reader
-   * @throws javax.xml.stream.XMLStreamException the xml stream exception
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
+   * @throws XMLStreamException the xml stream exception
+   * @throws ServiceXmlDeserializationException the service xml deserialization exception
    */
   public void readTextValueFromXml(EwsServiceXmlReader reader)
       throws XMLStreamException, ServiceXmlDeserializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/UserConfigurationDictionary.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/UserConfigurationDictionary.java
@@ -233,8 +233,8 @@ public final class UserConfigurationDictionary extends ComplexProperty
    * Writes elements to XML.
    *
    * @param writer accepts EwsServiceXmlWriter
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)
@@ -257,11 +257,11 @@ public final class UserConfigurationDictionary extends ComplexProperty
   /**
    * Writes a dictionary object (key or value) to Xml.
    *
-   * @param writer           The writer.
-   * @param xmlElementName   The Xml element name.
-   * @param dictionaryObject The object to write.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer           the writer
+   * @param xmlElementName   the Xml element name
+   * @param dictionaryObject the object to write
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   private void writeObjectToXml(EwsServiceXmlWriter writer,
       String xmlElementName, Object dictionaryObject)
@@ -299,8 +299,8 @@ public final class UserConfigurationDictionary extends ComplexProperty
    *                         an array of strings, an array of bytes (which will be encoded into base64) <br />
    *                         or a single value. Single values can be: <br />
    *                         - datetime, boolean, byte, int, long, string
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   private void writeObjectValueToXml(final EwsServiceXmlWriter writer,
       final Object dictionaryObject) throws XMLStreamException,
@@ -378,10 +378,10 @@ public final class UserConfigurationDictionary extends ComplexProperty
   /**
    * Writes a dictionary entry type to Xml.
    *
-   * @param writer               The writer.
-   * @param dictionaryObjectType Type to write.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer               the writer
+   * @param dictionaryObjectType type to write
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   private void writeEntryTypeToXml(EwsServiceXmlWriter writer,
       UserConfigurationDictionaryObjectType dictionaryObjectType)
@@ -396,10 +396,10 @@ public final class UserConfigurationDictionary extends ComplexProperty
   /**
    * Writes a dictionary entry value to Xml.
    *
-   * @param writer The writer.
-   * @param value  Value to write.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer the writer
+   * @param value  value to write
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   private void writeEntryValueToXml(EwsServiceXmlWriter writer, String value)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/UserId.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/UserId.java
@@ -235,8 +235,8 @@ public class UserId extends ComplexProperty {
    * Writes elements to XML.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeElementsToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/availability/OofSettings.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/availability/OofSettings.java
@@ -81,8 +81,8 @@ public final class OofSettings extends ComplexProperty implements ISelfValidate 
    * @param oofReply       The oof reply
    * @param writer         The writer
    * @param xmlElementName Name of the xml element
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   private void serializeOofReply(OofReply oofReply,
       EwsServiceXmlWriter writer, String xmlElementName)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/availability/Suggestion.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/availability/Suggestion.java
@@ -70,19 +70,14 @@ public final class Suggestion extends ComplexProperty {
    *
    * @param reader the reader
    * @return True if appropriate element was read.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws Exception                           the exception
+   * @throws Exception the exception
    */
   @Override
-  public boolean tryReadElementFromXml(EwsServiceXmlReader reader)
-      throws XMLStreamException, ServiceXmlDeserializationException,
-      Exception {
+  public boolean tryReadElementFromXml(EwsServiceXmlReader reader) throws Exception {
     if (reader.getLocalName().equals(XmlElementNames.Date)) {
       SimpleDateFormat sdfin = new SimpleDateFormat(
           "yyyy-MM-dd'T'HH:mm:ss");
-      Date tempDate = sdfin.parse(reader.readElementValue());
-      this.date = tempDate;
+      this.date = sdfin.parse(reader.readElementValue());
       return true;
     } else if (reader.getLocalName().equals(XmlElementNames.DayQuality)) {
       this.quality = reader.readElementValue(SuggestionQuality.class);

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/recurrence/DayOfTheWeekCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/recurrence/DayOfTheWeekCollection.java
@@ -102,8 +102,8 @@ public final class DayOfTheWeekCollection extends ComplexProperty implements
    *
    * @param writer         the writer
    * @param xmlElementName the xml element name
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override public void writeToXml(EwsServiceXmlWriter writer, String xmlElementName)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/recurrence/pattern/Recurrence.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/recurrence/pattern/Recurrence.java
@@ -55,6 +55,12 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.Iterator;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Iterator;
+
 /**
  * Represents a recurrence pattern, as used by Appointment and Task item.
  */
@@ -112,14 +118,9 @@ public abstract class Recurrence extends ComplexProperty {
    * Write property to XML.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
-   * @throws ServiceValidationException          the service validation exception
-   * @throws Exception                           the exception
+   * @throws Exception the exception
    */
-  public void internalWritePropertiesToXml(EwsServiceXmlWriter writer)
-      throws XMLStreamException, ServiceXmlSerializationException,
-      ServiceValidationException, Exception {
+  public void internalWritePropertiesToXml(EwsServiceXmlWriter writer) throws Exception {
   }
 
   /**
@@ -422,15 +423,10 @@ public abstract class Recurrence extends ComplexProperty {
      * Write property to XML.
      *
      * @param writer the writer
-     * @throws javax.xml.stream.XMLStreamException the xML stream exception
-     * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
-     * @throws microsoft.exchange.webservices.data.exception.ServiceValidationException          the service validation exception
-     * @throws Exception                           the exception
+     * @throws Exception the exception
      */
     @Override
-    public void internalWritePropertiesToXml(EwsServiceXmlWriter writer)
-        throws XMLStreamException, ServiceXmlSerializationException,
-        ServiceValidationException, Exception {
+    public void internalWritePropertiesToXml(EwsServiceXmlWriter writer) throws Exception {
       super.internalWritePropertiesToXml(writer);
 
       writer.writeElementValue(XmlNamespace.Types,

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/recurrence/range/EndDateRecurrenceRange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/recurrence/range/EndDateRecurrenceRange.java
@@ -88,8 +88,8 @@ public final class EndDateRecurrenceRange extends RecurrenceRange {
    * Writes the elements to XML.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeElementsToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/recurrence/range/NumberedRecurrenceRange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/recurrence/range/NumberedRecurrenceRange.java
@@ -87,8 +87,8 @@ public final class NumberedRecurrenceRange extends RecurrenceRange {
    * Writes the elements to XML..
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeElementsToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/recurrence/range/RecurrenceRange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/recurrence/range/RecurrenceRange.java
@@ -27,8 +27,6 @@ import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
 import microsoft.exchange.webservices.data.core.EwsServiceXmlWriter;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
-import microsoft.exchange.webservices.data.exception.ServiceValidationException;
-import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
 import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
 import microsoft.exchange.webservices.data.property.complex.ComplexProperty;
 import microsoft.exchange.webservices.data.property.complex.recurrence.pattern.Recurrence;
@@ -36,7 +34,6 @@ import microsoft.exchange.webservices.data.property.complex.recurrence.pattern.R
 import javax.xml.stream.XMLStreamException;
 
 import java.text.DateFormat;
-import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
@@ -85,13 +82,9 @@ public abstract class RecurrenceRange extends ComplexProperty {
    * Setup the recurrence.
    *
    * @param recurrence the new up recurrence
-   * @throws InstantiationException     the instantiation exception
-   * @throws IllegalAccessException     the illegal access exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceValidationException the service validation exception
-   * @throws Exception                  the exception
+   * @throws Exception the exception
    */
-  public void setupRecurrence(Recurrence recurrence)
-      throws InstantiationException, IllegalAccessException, ServiceValidationException, Exception {
+  public void setupRecurrence(Recurrence recurrence) throws Exception {
     recurrence.setStartDate(this.getStartDate());
   }
 
@@ -99,8 +92,8 @@ public abstract class RecurrenceRange extends ComplexProperty {
    * Writes elements to XML..
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeElementsToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {
@@ -117,17 +110,10 @@ public abstract class RecurrenceRange extends ComplexProperty {
    *
    * @param reader the reader
    * @return True if element was read
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws InstantiationException              the instantiation exception
-   * @throws IllegalAccessException              the illegal access exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws java.text.ParseException            the parse exception
-   * @throws Exception                           the exception
+   * @throws Exception the exception
    */
   public boolean tryReadElementFromXml(EwsServiceXmlReader reader)
-      throws ServiceXmlDeserializationException, InstantiationException,
-      IllegalAccessException, XMLStreamException, ParseException,
-      Exception {
+      throws Exception {
     if (reader.getLocalName().equals(XmlElementNames.StartDate)) {
       //this.startDate = reader.readElementValueAsDateTime();
       Date startDate = reader.readElementValueAsUnspecifiedDate();

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/time/AbsoluteDateTransition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/time/AbsoluteDateTransition.java
@@ -86,8 +86,8 @@ public class AbsoluteDateTransition extends TimeZoneTransition {
    * Writes elements to XML.
    *
    * @param writer the writer
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/time/AbsoluteDayOfMonthTransition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/time/AbsoluteDayOfMonthTransition.java
@@ -84,8 +84,8 @@ class AbsoluteDayOfMonthTransition extends AbsoluteMonthTransition {
    * Writes elements to XML.
    *
    * @param writer the writer
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/time/AbsoluteMonthTransition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/time/AbsoluteMonthTransition.java
@@ -82,8 +82,8 @@ abstract class AbsoluteMonthTransition extends TimeZoneTransition {
    * Writes elements to XML.
    *
    * @param writer the writer
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/time/RelativeDayOfMonthTransition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/time/RelativeDayOfMonthTransition.java
@@ -87,8 +87,8 @@ class RelativeDayOfMonthTransition extends AbsoluteMonthTransition {
    * Writes elements to XML.
    *
    * @param writer the writer
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/time/TimeZoneTransition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/time/TimeZoneTransition.java
@@ -148,8 +148,8 @@ public class TimeZoneTransition extends ComplexProperty {
    * Writes elements to XML.
    *
    * @param writer the writer
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
    */
   @Override
   public void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/main/java/microsoft/exchange/webservices/data/property/definition/PropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/definition/PropertyDefinition.java
@@ -29,12 +29,6 @@ import microsoft.exchange.webservices.data.core.PropertyBag;
 import microsoft.exchange.webservices.data.core.service.schema.ServiceObjectSchema;
 import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.PropertyDefinitionFlags;
-import microsoft.exchange.webservices.data.exception.ServiceLocalException;
-import microsoft.exchange.webservices.data.exception.ServiceObjectPropertyException;
-import microsoft.exchange.webservices.data.exception.ServiceValidationException;
-import microsoft.exchange.webservices.data.exception.ServiceVersionException;
-import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
-import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -179,36 +173,21 @@ public abstract class PropertyDefinition extends
    *
    * @param reader      The reader.
    * @param propertyBag The property bag.
-   * @throws ServiceXmlDeserializationException  the service xml deserialization exception
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws InstantiationException              the instantiation exception
-   * @throws IllegalAccessException              the illegal access exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceObjectPropertyException      the service object property exception
-   * @throws ServiceVersionException             the service version exception
-   * @throws Exception                           the exception
+   * @throws Exception the exception
    */
   public abstract void loadPropertyValueFromXml(EwsServiceXmlReader reader, PropertyBag propertyBag)
-      throws ServiceXmlDeserializationException, XMLStreamException,
-      InstantiationException, IllegalAccessException, ServiceObjectPropertyException, ServiceVersionException, Exception;
+      throws Exception;
 
   /**
    * Writes the property value to XML.
    *
-   * @param writer            The writer.
-   * @param propertyBag       The property bag.
-   * @param isUpdateOperation Indicates whether the context is an update operation.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException               the service local exception
-   * @throws InstantiationException              the instantiation exception
-   * @throws IllegalAccessException              the illegal access exception
-   * @throws ServiceValidationException          the service validation exception
-   * @throws Exception                           the exception
+   * @param writer            the writer
+   * @param propertyBag       the property bag
+   * @param isUpdateOperation indicates whether the context is an update operation
+   * @throws Exception the exception
    */
   public abstract void writePropertyValueToXml(EwsServiceXmlWriter writer, PropertyBag propertyBag,
-      boolean isUpdateOperation)
-      throws XMLStreamException, ServiceXmlSerializationException, ServiceLocalException, InstantiationException,
-      IllegalAccessException, ServiceValidationException, Exception;
+      boolean isUpdateOperation) throws Exception;
 
   /**
    * Gets the name of the XML element.

--- a/src/main/java/microsoft/exchange/webservices/data/property/definition/PropertyDefinitionBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/definition/PropertyDefinitionBase.java
@@ -117,8 +117,8 @@ public abstract class PropertyDefinitionBase {
    * Writes to XML.
    *
    * @param writer The writer.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/definition/StartTimeZonePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/definition/StartTimeZonePropertyDefinition.java
@@ -103,8 +103,8 @@ public class StartTimeZonePropertyDefinition extends TimeZonePropertyDefinition 
    * Writes to XML.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public void writeToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/property/definition/TimeZonePropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/definition/TimeZonePropertyDefinition.java
@@ -70,10 +70,7 @@ public class TimeZonePropertyDefinition extends PropertyDefinition {
    * @param writer            the writer
    * @param propertyBag       the property bag
    * @param isUpdateOperation the is update operation
-   * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
-   * @throws javax.xml.stream.XMLStreamException                       the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException                          the service xml serialization exception
-   * @throws Exception                                                 the exception
+   * @throws Exception the exception
    */
   public void writePropertyValueToXml(EwsServiceXmlWriter writer, PropertyBag propertyBag,
       boolean isUpdateOperation) throws Exception {

--- a/src/main/java/microsoft/exchange/webservices/data/property/definition/TypedPropertyDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/definition/TypedPropertyDefinition.java
@@ -30,7 +30,6 @@ import microsoft.exchange.webservices.data.enumeration.ExchangeVersion;
 import microsoft.exchange.webservices.data.enumeration.PropertyDefinitionFlags;
 import microsoft.exchange.webservices.data.enumeration.XmlNamespace;
 import microsoft.exchange.webservices.data.exception.ServiceLocalException;
-import microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -145,13 +144,11 @@ abstract class TypedPropertyDefinition<T extends Serializable> extends PropertyD
    * @param writer            The writer.
    * @param propertyBag       The property bag.
    * @param isUpdateOperation Indicates whether the context is an update operation.
-   * @throws javax.xml.stream.XMLStreamException                       the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException                          the service xml serialization exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceLocalException the service local exception
    */
   @Override public void writePropertyValueToXml(EwsServiceXmlWriter writer, PropertyBag propertyBag,
-      boolean isUpdateOperation)
-      throws XMLStreamException, ServiceXmlSerializationException, ServiceLocalException {
+      boolean isUpdateOperation) throws XMLStreamException, ServiceLocalException {
     T value = propertyBag.getObjectFromPropertyDefinition(this);
 
     if (value != null) {

--- a/src/main/java/microsoft/exchange/webservices/data/search/Grouping.java
+++ b/src/main/java/microsoft/exchange/webservices/data/search/Grouping.java
@@ -107,9 +107,9 @@ public final class Grouping implements ISelfValidate {
   /**
    * Writes to XML.
    *
-   * @param writer The Writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   protected void writeToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/search/ItemView.java
+++ b/src/main/java/microsoft/exchange/webservices/data/search/ItemView.java
@@ -102,8 +102,8 @@ public final class ItemView extends PagedView {
    *
    * @param writer  the writer
    * @param groupBy the group by
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected void internalWriteSearchSettingsToXml(EwsServiceXmlWriter writer,
@@ -116,8 +116,8 @@ public final class ItemView extends PagedView {
    * Writes OrderBy property to XML.
    *
    * @param writer the writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override public void writeOrderByToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/search/OrderByCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/search/OrderByCollection.java
@@ -169,8 +169,8 @@ public final class OrderByCollection implements
    *
    * @param writer         the writer
    * @param xmlElementName the xml element name
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   protected void writeToXml(EwsServiceXmlWriter writer, String xmlElementName)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/search/PagedView.java
+++ b/src/main/java/microsoft/exchange/webservices/data/search/PagedView.java
@@ -87,10 +87,10 @@ public abstract class PagedView extends ViewBase {
   /**
    * Internals the write search settings to XML.
    *
-   * @param writer  The writer
-   * @param groupBy The group by clause.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer  the writer
+   * @param groupBy the group by clause
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override
   protected void internalWriteSearchSettingsToXml(EwsServiceXmlWriter writer,
@@ -104,9 +104,9 @@ public abstract class PagedView extends ViewBase {
   /**
    * Writes OrderBy property to XML.
    *
-   * @param writer The Writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Override public void writeOrderByToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException {

--- a/src/main/java/microsoft/exchange/webservices/data/search/ViewBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/search/ViewBase.java
@@ -91,10 +91,10 @@ public abstract class ViewBase {
   /**
    * Writes the search settings to XML.
    *
-   * @param writer  The Writer
-   * @param groupBy The group by clause.
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer  the writer
+   * @param groupBy the group by clause
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   protected abstract void internalWriteSearchSettingsToXml(
       EwsServiceXmlWriter writer, Grouping groupBy)
@@ -103,9 +103,9 @@ public abstract class ViewBase {
   /**
    * Writes OrderBy property to XML.
    *
-   * @param writer The Writer
-   * @throws javax.xml.stream.XMLStreamException the xML stream exception
-   * @throws ServiceXmlSerializationException    the service xml serialization exception
+   * @param writer the writer
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   public abstract void writeOrderByToXml(EwsServiceXmlWriter writer)
       throws XMLStreamException, ServiceXmlSerializationException;

--- a/src/main/java/microsoft/exchange/webservices/data/search/filter/SearchFilter.java
+++ b/src/main/java/microsoft/exchange/webservices/data/search/filter/SearchFilter.java
@@ -300,8 +300,8 @@ public abstract class SearchFilter extends ComplexProperty {
      * Writes the elements to Xml.
      *
      * @param writer the writer
-     * @throws javax.xml.stream.XMLStreamException the xML stream exception
-     * @throws ServiceXmlSerializationException    the service xml serialization exception
+     * @throws XMLStreamException the XML stream exception
+     * @throws ServiceXmlSerializationException the service xml serialization exception
      */
     @Override
     public void writeElementsToXml(EwsServiceXmlWriter writer)
@@ -993,8 +993,8 @@ public abstract class SearchFilter extends ComplexProperty {
      * Writes the elements to XML.
      *
      * @param writer the writer
-     * @throws javax.xml.stream.XMLStreamException the xML stream exception
-     * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException    the service xml serialization exception
+     * @throws XMLStreamException the XML stream exception
+     * @throws ServiceXmlSerializationException the service xml serialization exception
      */
     @Override
     public void writeElementsToXml(EwsServiceXmlWriter writer)

--- a/src/test/java/microsoft/exchange/webservices/data/autodiscover/request/GetUserSettingsRequestTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/autodiscover/request/GetUserSettingsRequestTest.java
@@ -119,11 +119,11 @@ public class GetUserSettingsRequestTest extends BaseTest {
   }
 
   /**
-   * Nothing should be writen to the Outputstream if expectPartnerToken is not set
+   * Nothing should be written to the OutputStream if expectPartnerToken is not set.
    *
    * @throws ServiceValidationException
-   * @throws XMLStreamException
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Test
   public void testWriteExtraCustomSoapHeadersToXmlWithoutPartnertoken()
@@ -137,7 +137,7 @@ public class GetUserSettingsRequestTest extends BaseTest {
     getUserSettingsRequest.writeExtraCustomSoapHeadersToXml(
         new EwsServiceXmlWriter(exchangeServiceBaseMock, byteArrayOutputStream));
 
-    // nothing should be writen to the outputstream
+    // nothing should be writyen to the outputstream
     Assert.assertArrayEquals(byteArrayOutputStream.toByteArray(), new ByteArrayOutputStream().toByteArray());
 
     // HTTP
@@ -148,16 +148,16 @@ public class GetUserSettingsRequestTest extends BaseTest {
     getUserSettingsRequest.writeExtraCustomSoapHeadersToXml(
         new EwsServiceXmlWriter(exchangeServiceBaseMock, byteArrayOutputStream));
 
-    // nothing should be writen to the outputstream
+    // nothing should be written to the outputstream
     Assert.assertArrayEquals(byteArrayOutputStream.toByteArray(), new ByteArrayOutputStream().toByteArray());
   }
 
   /**
-   * Test if content is added correctly if expectPartnerToken is set
+   * Test if content is added correctly if expectPartnerToken is set.
    *
-   * @throws microsoft.exchange.webservices.data.exception.ServiceValidationException
-   * @throws XMLStreamException
-   * @throws microsoft.exchange.webservices.data.exception.ServiceXmlSerializationException
+   * @throws ServiceValidationException
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Test
   public void testWriteExtraCustomSoapHeadersToXmlWithPartnertoken()
@@ -178,11 +178,11 @@ public class GetUserSettingsRequestTest extends BaseTest {
   }
 
   /**
-   * Initialising a GetUserSettingsRequest with Http should lead to an ServiceValidationException
+   * Initialising a GetUserSettingsRequest with Http should lead to an ServiceValidationException.
    *
    * @throws ServiceValidationException
-   * @throws XMLStreamException
-   * @throws ServiceXmlSerializationException
+   * @throws XMLStreamException the XML stream exception
+   * @throws ServiceXmlSerializationException the service xml serialization exception
    */
   @Test(expected = ServiceValidationException.class)
   public void testWriteExtraCustomSoapHeadersToXmlWithPartnertoken2()

--- a/src/test/java/microsoft/exchange/webservices/data/property/complex/UniqueBodyTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/property/complex/UniqueBodyTest.java
@@ -33,13 +33,10 @@ import microsoft.exchange.webservices.data.core.EwsServiceXmlWriter;
 import microsoft.exchange.webservices.data.core.XmlAttributeNames;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.enumeration.BodyType;
-import microsoft.exchange.webservices.data.exception.ServiceXmlDeserializationException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-
-import javax.xml.stream.XMLStreamException;
 
 public class UniqueBodyTest {
 
@@ -89,7 +86,7 @@ public class UniqueBodyTest {
     assertEquals(text, impl.toString());
   }
 
-  private void setTextToImpl(String myText) throws XMLStreamException, ServiceXmlDeserializationException {
+  private void setTextToImpl(String myText) throws Exception {
     doReturn(myText).when(reader).readValue();
     impl.readTextValueFromXml(reader);
   }


### PR DESCRIPTION
It is just a small part of fixes in Javadoc (and corresponding code, usually methods signatures). The initial idea was to cleanup everything to remove Maven profile `default-jdk18-profile`, but there are a lot of javadoc issues.

I'm not sure that I will fix all of them, so it will be useful to hear some feedback about this work. Is it useful or not? I can continue a little bit.