### PR TITLE
Fix #284 to enable adding headers (e.g. OAuth)

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
@@ -73,12 +73,6 @@ import java.util.TimeZone;
  * Represents an abstract binding to an Exchange Service.
  */
 public abstract class ExchangeServiceBase implements Closeable {
-
-  /**
-   * Prefix for "extended" headers.
-   */
-  private static final String ExtendedHeaderPrefix = "X-";
-
   /**
    * The credential.
    */
@@ -484,12 +478,6 @@ public abstract class ExchangeServiceBase implements Closeable {
    * @throws microsoft.exchange.webservices.data.exception.ServiceLocalException the service local exception
    */
   public void validate() throws ServiceLocalException {
-    // E14:302056 -- Allow clients to add HTTP request headers with 'X-' prefix but no others.
-    for (Map.Entry<String, String> key : this.httpHeaders.entrySet()) {
-      if (!key.getKey().startsWith(ExtendedHeaderPrefix)) {
-        throw new ServiceValidationException(String.format("HTTP header '%s' isn't permitted. Only HTTP headers with the 'X-' prefix are permitted.", key));
-      }
-    }
   }
 
   /**


### PR DESCRIPTION
This check was removed from EWS Managed API since 2012.  Removing the check enables adding headers like OAuth.