### PR TITLE
fix for https://github.com/OfficeDev/ews-java-api/issues/316

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
@@ -390,6 +390,7 @@ public class AutodiscoverService extends ExchangeServiceBase
 
     try {
       request = new HttpClientWebRequest(httpClient, httpContext);
+      request.setProxy(getWebProxy());
 
       try {
         request.setUrl(URI.create(url).toURL());
@@ -1511,6 +1512,7 @@ public class AutodiscoverService extends ExchangeServiceBase
       HttpWebRequest request = null;
       try {
         request = new HttpClientWebRequest(httpClient, httpContext);
+        request.setProxy(getWebProxy());
 
         try {
           request.setUrl(autoDiscoverUrl.toURL());

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
@@ -3604,6 +3604,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
       throws Exception {
 
     AutodiscoverService autodiscoverService = new AutodiscoverService(this, requestedServerVersion);
+    autodiscoverService.setWebProxy(getWebProxy());
+
     autodiscoverService
         .setRedirectionUrlValidationCallback(validateRedirectionUrlCallback);
     autodiscoverService.setEnableScpLookup(this.getEnableScpLookup());

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
@@ -282,6 +282,8 @@ public abstract class ExchangeServiceBase implements Closeable {
     }
 
     request = new HttpClientWebRequest(httpClient, httpContext);
+    request.setProxy(getWebProxy());
+
     try {
       request.setUrl(url.toURL());
     } catch (MalformedURLException e) {


### PR DESCRIPTION
Per my analysis, WebProxy even though was set in ExchangeService.java, it was not passed onto the HttpClientWebRequest request and also in case of service.autodiscoverUrl() it was not set to the instance of new AutodiscoverService.
Kindly review these changes and let me know if you guys have any feedback.

Cheers,
K