### PR TITLE
Remove unnecessary "instanceof" check in ComplexPropertyCollection

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/ComplexProperty.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/ComplexProperty.java
@@ -372,20 +372,18 @@ public abstract class ComplexProperty implements ISelfValidate, ComplexFunctionD
   /**
    * Implements ISelfValidate.validate. Validates this instance.
    *
-   * @throws ServiceValidationException the service validation exception
-   * @throws Exception                  the exception
+   * @throws Exception the exception
    */
-  public void validate() throws ServiceValidationException, Exception {
+  public void validate() throws Exception {
     this.internalValidate();
   }
 
   /**
    * Validates this instance.
    *
-   * @throws ServiceValidationException the service validation exception
-   * @throws Exception
+   * @throws Exception the exception
    */
-  protected void internalValidate() throws ServiceValidationException, Exception {
+  protected void internalValidate() throws Exception {
   }
 
   public Boolean func(EwsServiceXmlReader reader) throws Exception {

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/ComplexPropertyCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/ComplexPropertyCollection.java
@@ -48,7 +48,7 @@ import java.util.List;
 public abstract class ComplexPropertyCollection
     <TComplexProperty extends ComplexProperty>
     extends ComplexProperty implements ICustomXmlUpdateSerializer,
-    Iterable<TComplexProperty>, IComplexPropertyChangedDelegate {
+    Iterable<TComplexProperty>, IComplexPropertyChangedDelegate<TComplexProperty> {
 
   /**
    * The item.
@@ -101,12 +101,11 @@ public abstract class ComplexPropertyCollection
   /**
    * Item changed.
    *
-   * @param complexProperty The complex property.
+   * @param property The complex property.
    */
-  protected void itemChanged(final ComplexProperty complexProperty) {
-    final TComplexProperty property = (TComplexProperty) complexProperty;
+  protected void itemChanged(final TComplexProperty property) {
     EwsUtilities.ewsAssert(
-      complexProperty != null, "ComplexPropertyCollection.ItemChanged",
+      property != null, "ComplexPropertyCollection.ItemChanged",
       "The complexProperty argument must be not null"
     );
 
@@ -332,7 +331,7 @@ public abstract class ComplexPropertyCollection
    * @param complexProperty accepts ComplexProperty
    */
   @Override
-  public void complexPropertyChanged(ComplexProperty complexProperty) {
+  public void complexPropertyChanged(final TComplexProperty complexProperty) {
     this.itemChanged(complexProperty);
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/ComplexPropertyCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/ComplexPropertyCollection.java
@@ -53,24 +53,24 @@ public abstract class ComplexPropertyCollection
   /**
    * The item.
    */
-  private List<TComplexProperty> items = new ArrayList<TComplexProperty>();
+  private final List<TComplexProperty> items = new ArrayList<TComplexProperty>();
 
   /**
    * The added item.
    */
-  private List<TComplexProperty> addedItems =
+  private final List<TComplexProperty> addedItems =
       new ArrayList<TComplexProperty>();
 
   /**
    * The modified item.
    */
-  private List<TComplexProperty> modifiedItems =
+  private final List<TComplexProperty> modifiedItems =
       new ArrayList<TComplexProperty>();
 
   /**
    * The removed item.
    */
-  private List<TComplexProperty> removedItems =
+  private final List<TComplexProperty> removedItems =
       new ArrayList<TComplexProperty>();
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/ComplexPropertyCollection.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/ComplexPropertyCollection.java
@@ -103,15 +103,13 @@ public abstract class ComplexPropertyCollection
    *
    * @param complexProperty The complex property.
    */
-  protected void itemChanged(ComplexProperty complexProperty) {
-    EwsUtilities
-        .ewsAssert(complexProperty instanceof ComplexProperty, "ComplexPropertyCollection.ItemChanged",
-                   String.format("ComplexPropertyCollection." +
-                                 "ItemChanged: the type of " +
-                                 "the complexProperty argument " +
-                                 "(%s) is not supported.", complexProperty.getClass().getName()));
+  protected void itemChanged(final ComplexProperty complexProperty) {
+    final TComplexProperty property = (TComplexProperty) complexProperty;
+    EwsUtilities.ewsAssert(
+      complexProperty != null, "ComplexPropertyCollection.ItemChanged",
+      "The complexProperty argument must be not null"
+    );
 
-    TComplexProperty property = (TComplexProperty) complexProperty;
     if (!this.addedItems.contains(property)) {
       if (!this.modifiedItems.contains(property)) {
         this.modifiedItems.add(property);

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/DictionaryProperty.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/DictionaryProperty.java
@@ -50,7 +50,7 @@ import java.util.Map.Entry;
 @EditorBrowsable(state = EditorBrowsableState.Never)
 public abstract class DictionaryProperty
     <TKey, TEntry extends DictionaryEntryProperty<TKey>>
-    extends ComplexProperty implements ICustomXmlUpdateSerializer, IComplexPropertyChangedDelegate {
+    extends ComplexProperty implements ICustomXmlUpdateSerializer, IComplexPropertyChangedDelegate<TEntry> {
 
   /**
    * The entries.
@@ -77,8 +77,8 @@ public abstract class DictionaryProperty
    *
    * @param complexProperty the complex property
    */
-  private void entryChanged(ComplexProperty complexProperty) {
-    TKey key = ((TEntry) complexProperty).getKey();
+  private void entryChanged(final TEntry complexProperty) {
+    TKey key = complexProperty.getKey();
 
     if (!this.addedEntries.contains(key) && !this.modifiedEntries.contains(key)) {
       this.modifiedEntries.add(key);
@@ -188,8 +188,8 @@ public abstract class DictionaryProperty
    * @param complexProperty accepts ComplexProperty
    */
   @Override
-  public void complexPropertyChanged(ComplexProperty complexProperty) {
-    this.entryChanged(complexProperty);
+  public void complexPropertyChanged(final TEntry complexProperty) {
+    entryChanged(complexProperty);
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/IComplexPropertyChangedDelegate.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/IComplexPropertyChangedDelegate.java
@@ -26,12 +26,13 @@ package microsoft.exchange.webservices.data.property.complex;
 /**
  * The Interface ComplexPropertyChangedDelegateInterface.
  */
-public interface IComplexPropertyChangedDelegate {
+public interface IComplexPropertyChangedDelegate<TComplexProperty extends ComplexProperty> {
 
   /**
    * Complex property changed.
    *
    * @param complexProperty the complex property
    */
-  void complexPropertyChanged(ComplexProperty complexProperty);
+  void complexPropertyChanged(TComplexProperty complexProperty);
+
 }

--- a/src/test/java/microsoft/exchange/webservices/data/property/complex/ComplexPropertyCollectionTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/property/complex/ComplexPropertyCollectionTest.java
@@ -1,0 +1,53 @@
+package microsoft.exchange.webservices.data.property.complex;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.List;
+
+/**
+ * @author Vladislav Bauer
+ */
+
+@RunWith(JUnit4.class)
+public class ComplexPropertyCollectionTest {
+
+  @Test
+  public void testComplexPropertyChangedPositive() {
+    final ComplexPropertyCollection<ComplexProperty> collection = createFakeComplexPropertyCollection();
+
+    final ComplexProperty property = createFakeComplexProperty();
+    collection.complexPropertyChanged(property);
+
+    final List<ComplexProperty> modifiedItems = collection.getModifiedItems();
+    Assert.assertTrue(collection.getAddedItems().isEmpty());
+    Assert.assertTrue(modifiedItems.contains(property));
+    Assert.assertEquals(1, modifiedItems.size());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testComplexPropertyChangedNegative() {
+    final ComplexPropertyCollection<ComplexProperty> collection = createFakeComplexPropertyCollection();
+    collection.complexPropertyChanged(null);
+    Assert.fail();
+  }
+
+
+  private ComplexProperty createFakeComplexProperty() {
+    return new ComplexProperty() {};
+  }
+
+  private ComplexPropertyCollection<ComplexProperty> createFakeComplexPropertyCollection() {
+    return new ComplexPropertyCollection<ComplexProperty>() {
+      @Override protected ComplexProperty createComplexProperty(final String xmlElementName) {
+        return null;
+      }
+      @Override protected String getCollectionItemXmlElementName(final ComplexProperty complexProperty) {
+        return null;
+      }
+    };
+  }
+
+}

--- a/src/test/java/microsoft/exchange/webservices/data/property/complex/ComplexPropertyCollectionTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/property/complex/ComplexPropertyCollectionTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License
+ * Copyright (c) 2012 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 package microsoft.exchange.webservices.data.property.complex;
 
 import org.junit.Assert;
@@ -7,9 +30,6 @@ import org.junit.runners.JUnit4;
 
 import java.util.List;
 
-/**
- * @author Vladislav Bauer
- */
 
 @RunWith(JUnit4.class)
 public class ComplexPropertyCollectionTest {
@@ -31,7 +51,6 @@ public class ComplexPropertyCollectionTest {
   public void testComplexPropertyChangedNegative() {
     final ComplexPropertyCollection<ComplexProperty> collection = createFakeComplexPropertyCollection();
     collection.complexPropertyChanged(null);
-    Assert.fail();
   }
 
 


### PR DESCRIPTION
Parameter "complexProperty" is always `ComplexProperty`, I think it is unnecessary to make this check.