### PR TITLE
Fix for Issue #276 Streaming subscription throws connection error

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
@@ -3744,6 +3744,17 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
         .getAcceptGzipEncoding(), true);
   }
 
+  public HttpWebRequest prepareHttpPoolingWebRequest()
+	      throws ServiceLocalException, URISyntaxException {
+	    try {
+	      this.url = this.adjustServiceUriFromCredentials(this.getUrl());
+	    } catch (Exception e) {
+	      LOG.error(e);
+	    }
+	    return this.prepareHttpPoolingWebRequestForUrl(url, this
+	        .getAcceptGzipEncoding(), true);
+	  }
+
   /**
    * Processes an HTTP error response.
    *

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
@@ -23,11 +23,52 @@
 
 package microsoft.exchange.webservices.data.core;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.TimeZone;
+
 import microsoft.exchange.webservices.data.autodiscover.AutodiscoverService;
 import microsoft.exchange.webservices.data.autodiscover.IAutodiscoverRedirectionUrl;
+import microsoft.exchange.webservices.data.autodiscover.enumeration.UserSettingName;
 import microsoft.exchange.webservices.data.autodiscover.exception.AutodiscoverLocalException;
 import microsoft.exchange.webservices.data.autodiscover.request.ApplyConversationActionRequest;
 import microsoft.exchange.webservices.data.autodiscover.response.GetUserSettingsResponse;
+import microsoft.exchange.webservices.data.core.enumeration.availability.AvailabilityData;
+import microsoft.exchange.webservices.data.core.enumeration.misc.ConversationActionType;
+import microsoft.exchange.webservices.data.core.enumeration.misc.DateTimePrecision;
+import microsoft.exchange.webservices.data.core.enumeration.misc.ExchangeVersion;
+import microsoft.exchange.webservices.data.core.enumeration.misc.IdFormat;
+import microsoft.exchange.webservices.data.core.enumeration.misc.TraceFlags;
+import microsoft.exchange.webservices.data.core.enumeration.misc.UserConfigurationProperties;
+import microsoft.exchange.webservices.data.core.enumeration.notification.EventType;
+import microsoft.exchange.webservices.data.core.enumeration.property.BodyType;
+import microsoft.exchange.webservices.data.core.enumeration.property.WellKnownFolderName;
+import microsoft.exchange.webservices.data.core.enumeration.search.ResolveNameSearchLocation;
+import microsoft.exchange.webservices.data.core.enumeration.service.ConflictResolutionMode;
+import microsoft.exchange.webservices.data.core.enumeration.service.DeleteMode;
+import microsoft.exchange.webservices.data.core.enumeration.service.MeetingRequestsDeliveryScope;
+import microsoft.exchange.webservices.data.core.enumeration.service.MessageDisposition;
+import microsoft.exchange.webservices.data.core.enumeration.service.SendCancellationsMode;
+import microsoft.exchange.webservices.data.core.enumeration.service.SendInvitationsMode;
+import microsoft.exchange.webservices.data.core.enumeration.service.SendInvitationsOrCancellationsMode;
+import microsoft.exchange.webservices.data.core.enumeration.service.SyncFolderItemsScope;
+import microsoft.exchange.webservices.data.core.enumeration.service.calendar.AffectedTaskOccurrence;
+import microsoft.exchange.webservices.data.core.enumeration.service.error.ServiceErrorHandling;
+import microsoft.exchange.webservices.data.core.exception.misc.ArgumentOutOfRangeException;
+import microsoft.exchange.webservices.data.core.exception.service.local.ServiceLocalException;
+import microsoft.exchange.webservices.data.core.exception.service.local.ServiceValidationException;
+import microsoft.exchange.webservices.data.core.exception.service.remote.AccountIsLockedException;
+import microsoft.exchange.webservices.data.core.exception.service.remote.ServiceRemoteException;
+import microsoft.exchange.webservices.data.core.exception.service.remote.ServiceResponseException;
 import microsoft.exchange.webservices.data.core.request.AddDelegateRequest;
 import microsoft.exchange.webservices.data.core.request.ConvertIdRequest;
 import microsoft.exchange.webservices.data.core.request.CopyFolderRequest;
@@ -101,34 +142,6 @@ import microsoft.exchange.webservices.data.core.service.folder.Folder;
 import microsoft.exchange.webservices.data.core.service.item.Appointment;
 import microsoft.exchange.webservices.data.core.service.item.Conversation;
 import microsoft.exchange.webservices.data.core.service.item.Item;
-import microsoft.exchange.webservices.data.core.enumeration.service.calendar.AffectedTaskOccurrence;
-import microsoft.exchange.webservices.data.core.enumeration.availability.AvailabilityData;
-import microsoft.exchange.webservices.data.core.enumeration.property.BodyType;
-import microsoft.exchange.webservices.data.core.enumeration.service.ConflictResolutionMode;
-import microsoft.exchange.webservices.data.core.enumeration.misc.ConversationActionType;
-import microsoft.exchange.webservices.data.core.enumeration.misc.DateTimePrecision;
-import microsoft.exchange.webservices.data.core.enumeration.service.DeleteMode;
-import microsoft.exchange.webservices.data.core.enumeration.notification.EventType;
-import microsoft.exchange.webservices.data.core.enumeration.misc.ExchangeVersion;
-import microsoft.exchange.webservices.data.core.enumeration.misc.IdFormat;
-import microsoft.exchange.webservices.data.core.enumeration.service.MeetingRequestsDeliveryScope;
-import microsoft.exchange.webservices.data.core.enumeration.service.MessageDisposition;
-import microsoft.exchange.webservices.data.core.enumeration.search.ResolveNameSearchLocation;
-import microsoft.exchange.webservices.data.core.enumeration.service.SendCancellationsMode;
-import microsoft.exchange.webservices.data.core.enumeration.service.SendInvitationsMode;
-import microsoft.exchange.webservices.data.core.enumeration.service.SendInvitationsOrCancellationsMode;
-import microsoft.exchange.webservices.data.core.enumeration.service.error.ServiceErrorHandling;
-import microsoft.exchange.webservices.data.core.enumeration.service.SyncFolderItemsScope;
-import microsoft.exchange.webservices.data.core.enumeration.misc.TraceFlags;
-import microsoft.exchange.webservices.data.core.enumeration.misc.UserConfigurationProperties;
-import microsoft.exchange.webservices.data.autodiscover.enumeration.UserSettingName;
-import microsoft.exchange.webservices.data.core.enumeration.property.WellKnownFolderName;
-import microsoft.exchange.webservices.data.core.exception.service.remote.AccountIsLockedException;
-import microsoft.exchange.webservices.data.core.exception.misc.ArgumentOutOfRangeException;
-import microsoft.exchange.webservices.data.core.exception.service.local.ServiceLocalException;
-import microsoft.exchange.webservices.data.core.exception.service.remote.ServiceRemoteException;
-import microsoft.exchange.webservices.data.core.exception.service.remote.ServiceResponseException;
-import microsoft.exchange.webservices.data.core.exception.service.local.ServiceValidationException;
 import microsoft.exchange.webservices.data.messaging.UnifiedMessaging;
 import microsoft.exchange.webservices.data.misc.AsyncCallback;
 import microsoft.exchange.webservices.data.misc.AsyncRequestResult;
@@ -178,23 +191,11 @@ import microsoft.exchange.webservices.data.search.filter.SearchFilter;
 import microsoft.exchange.webservices.data.sync.ChangeCollection;
 import microsoft.exchange.webservices.data.sync.FolderChange;
 import microsoft.exchange.webservices.data.sync.ItemChange;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
-
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.TimeZone;
 
 /**
  * Represents a binding to the Exchange Web Services.
@@ -3744,6 +3745,13 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
         .getAcceptGzipEncoding(), true);
   }
 
+  /**
+   * Prepares a http web request from a pooling connection manager, used for subscriptions.
+   * 
+   * @return A http web request
+   * @throws ServiceLocalException The service local exception
+   * @throws java.net.URISyntaxException the uRI syntax exception
+   */
   public HttpWebRequest prepareHttpPoolingWebRequest()
 	      throws ServiceLocalException, URISyntaxException {
 	    try {

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetStreamingEventsRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetStreamingEventsRequest.java
@@ -149,5 +149,9 @@ public class GetStreamingEventsRequest extends HangingServiceRequestBase<GetStre
     GetStreamingEventsRequest.heartbeatFrequency = heartbeatFrequency;
   }
 
-
+  @Override
+	protected HttpWebRequest buildEwsHttpWebRequest() throws Exception
+	{
+		return super.buildEwsHttpPoolingWebRequest();
+	}
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
@@ -665,14 +665,23 @@ public abstract class ServiceRequestBase<T> {
     return buildEwsHttpWebRequest(request);
   }
 
+  /**
+   * Builds a HttpWebRequest object from a pooling connection manager for current service request
+   * with exception handling.
+   * <p>
+   * Used for subscriptions.
+   * </p>
+   * 
+   * @return A HttpWebRequest instance
+   * @throws Exception on error
+   */
   protected HttpWebRequest buildEwsHttpPoolingWebRequest() throws Exception {
-     HttpWebRequest request = service.prepareHttpPoolingWebRequest();
+    HttpWebRequest request = service.prepareHttpPoolingWebRequest();
     return buildEwsHttpWebRequest(request);
   }
 
-private HttpWebRequest buildEwsHttpWebRequest(HttpWebRequest request) throws Exception
-{
-	try {
+  private HttpWebRequest buildEwsHttpWebRequest(HttpWebRequest request) throws Exception {
+    try {
 
       service.traceHttpRequestHeaders(TraceFlags.EwsRequestHttpHeaders, request);
 
@@ -680,7 +689,8 @@ private HttpWebRequest buildEwsHttpWebRequest(HttpWebRequest request) throws Exc
 
       EwsServiceXmlWriter writer = new EwsServiceXmlWriter(service, requestStream);
 
-      boolean needSignature = service.getCredentials() != null && service.getCredentials().isNeedSignature();
+      boolean needSignature =
+          service.getCredentials() != null && service.getCredentials().isNeedSignature();
       writer.setRequireWSSecurityUtilityNamespace(needSignature);
 
       writeToXml(writer);

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
@@ -661,8 +661,18 @@ public abstract class ServiceRequestBase<T> {
    * @throws Exception on error
    */
   protected HttpWebRequest buildEwsHttpWebRequest() throws Exception {
-    try {
       HttpWebRequest request = service.prepareHttpWebRequest();
+    return buildEwsHttpWebRequest(request);
+  }
+
+  protected HttpWebRequest buildEwsHttpPoolingWebRequest() throws Exception {
+     HttpWebRequest request = service.prepareHttpPoolingWebRequest();
+    return buildEwsHttpWebRequest(request);
+  }
+
+private HttpWebRequest buildEwsHttpWebRequest(HttpWebRequest request) throws Exception
+{
+	try {
 
       service.traceHttpRequestHeaders(TraceFlags.EwsRequestHttpHeaders, request);
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/SubscribeRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/SubscribeRequest.java
@@ -256,4 +256,9 @@ abstract class SubscribeRequest<TSubscription extends SubscriptionBase> extends
     this.watermark = watermark;
   }
 
+  @Override
+	protected HttpWebRequest buildEwsHttpWebRequest() throws Exception
+	{
+		return super.buildEwsHttpPoolingWebRequest();
+	}
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/UnsubscribeRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/UnsubscribeRequest.java
@@ -164,5 +164,9 @@ public class UnsubscribeRequest extends MultiResponseServiceRequest<ServiceRespo
   public void setSubscriptionId(String subscriptionId) {
     this.subscriptionId = subscriptionId;
   }
-
+  @Override
+ 	protected HttpWebRequest buildEwsHttpWebRequest() throws Exception
+ 	{
+		return super.buildEwsHttpPoolingWebRequest();
+ 	}
 }


### PR DESCRIPTION
Fixes issues with subscriptions (e.g. streaming) and now uses a PoolingHttpClientConnectionManager instead of BasicHttpClientConnectionManager.
Specifically, it will create a separate PoolingHttpClientConnectionManager for subscriptions while still retaining the BasicHttpClientConnectionManager for all other connections.

New pull request of #297 