### PR TITLE
travis deployment of site to gh-pages branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ env:
     - secure: "V37/WY3//w4fQUxmtKXw9dsU4iH5Z6HvTpBkZj+5DaX5h2Lj98FzALvkGSt7KvqVKQBbgETjs3HTMQkz6hwbLgX2okLKCQbmhZu3vQLqkWe6KPqnO1NOKSaU4vhCoGpScNWMiVxrzCHLHZf5tQu7d+1WVMk5GNlgGqeKVSnz5LY="
     - secure: "O9Mjx/mU5MLQsngcVbTf7AVMFo2Bh3ZWXwTyiLVXAfU7/VZX39vx30Mf2laNpewYqbiouix7fOkK76YS8459QRoLVBAQSwzjuGsZAwQvz7b7+r3kCS7rwGm7eCobJDbwItoxAxA00rI3gpyX/BnaX8aFutQw/0ZoPSPOH+LzR+4="
 
+branches:
+  except:
+    - gh-pages
+
 # cache local repository for speed of build
 cache:
   directories:

--- a/deploy_snapshot.sh
+++ b/deploy_snapshot.sh
@@ -21,7 +21,14 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+function on_exit {
+    # clean up
+    rm -f $HOME/.m2/settings.xml
+    rm -f $HOME/.config/hub
+}
+
 set -e # Any subsequent(*) commands which fail will cause the shell script to exit immediately
+trap on_exit EXIT # on exit do clean up
 
 if [ "$TRAVIS_REPO_SLUG" != "OfficeDev/ews-java-api" ]; then
     echo "[DEPLOY] Skipping snapshot deployment for repo:'$TRAVIS_REPO_SLUG'."
@@ -38,18 +45,16 @@ else
     # create settings.xml
     echo "<settings><servers><server><id>ossrh-snapshot</id><username>${OSSRHUSER}</username><password>${OSSRHPASS}</password></server></servers></settings>" > $HOME/.m2/settings.xml
     # deploy
-    if [ -z "${GPG_PASSPHRASE+xxx}" ]; then
+    if [ -z "${GPG_PASSPHRASE}" ]; then
        echo "[INFO] Deploying unsigned artifacts"
        mvn clean deploy --settings="$HOME/.m2/settings.xml" -Dmaven.test.skip=true
     else
        echo "[INFO] Deploying signed artifacts"
        mvn clean deploy --settings="$HOME/.m2/settings.xml" -Dmaven.test.skip=true -Dgpg.passphrase=$GPG_PASSPHRASE
     fi
-    # clean up
-    rm -f $HOME/.m2/settings.xml
     echo "[DEPLOY] Done deploying snapshot"
 
-    if [ -z "${GITHUB_USER+xxx}" ]; then
+    if [ -z "${GITHUB_USER}" ]; then
        echo "[GH-PAGES] Deployment of gh-pages skipped. No GITHUB_TOKEN set."
     else
        # download hub
@@ -59,9 +64,6 @@ else
        [[ -d "$HOME/.config" ]] || mkdir -m777 -v -p $HOME/.config
        echo -e "github.com:\n- user: ${GITHUB_USERNAME}\n  oauth_token: ${GITHUB_TOKEN}\n  protocol: https\n" > $HOME/.config/hub
 
-       git config --global user.email "travis@travis-ci.org"
-       git config --global user.name "travis-ci"
-
        mvn clean site
 
        echo "[GH-PAGES] Deploying gh-pages for $TRAVIS_BRANCH"
@@ -69,8 +71,8 @@ else
        # clone actual gh-pages repo
        cd "$HOME/OfficeDev"
        echo "[GH-PAGES] Cloning travis-user fork"
-       git clone -q --progress -b gh-pages --single-branch https://${GITHUB_TOKEN}@github.com/OfficeDev/ews-java-api.git gh-pages && cd gh-pages
-       git remote add upstream https://github.com/OfficeDev/ews-java-api.git
+       git clone -q --progress -b gh-pages --single-branch https://${GITHUB_TOKEN}@github.com/$TRAVIS_REPO_SLUG.git gh-pages && cd gh-pages
+       git remote add upstream https://github.com/$TRAVIS_REPO_SLUG.git
        echo "[GH-PAGES] Updating origin if needed"
        git fetch -q --progress upstream gh-pages
        git merge -q --progress upstream/gh-pages gh-pages
@@ -81,20 +83,18 @@ else
        mkdir -m777 -v -p "./docs/snapshots/$TRAVIS_BRANCH"
 
        # copy all the builded stuff into the snapshot dir
-       cp -Rf "$HOME/OfficeDev/ews-java-api/target/site/*" "./docs/snapshots/$TRAVIS_BRANCH"
+       cp -Rf "$HOME/$TRAVIS_REPO_SLUG/target/site/*" "./docs/snapshots/$TRAVIS_BRANCH"
 
-       git add .
+       git add -A
        echo "[GH-PAGES] Committing changes to local repository"
-       git commit --author "travis-ci <travis@travis-ci.org>" -m "[TRAVIS]Deploy mvn site to [gh-pages/$TRAVIS_BRANCH] @ $TRAVIS_BUILD_NUMBER"
+       git commit --author "travis-ci <travis@travis-ci.org>" -m "[TRAVIS]Deploy mvn site [ci skip] @ $TRAVIS_BUILD_NUMBER"
        echo "[GH-PAGES] Pushing changes to origin gh-pages"
        git push -fq --progress origin gh-pages
 
        echo "[GH-PAGES] Creating a PR"
-       eval "$HOME/download/hub-linux-amd64-2.2.1/hub pull-request -m "$(printf "[TRAVIS] UPDATE [gh-pages/$TRAVIS_BRANCH] @ $TRAVIS_BUILD_NUMBER\n\n$TRAVIS_BUILD_NUMBER\nAutomated Pull Request :shipit:")" -b 'OfficeDev/ews-java-api:gh-pages' -h ${GITHUB_USERNAME}/ews-java-api:gh-pages"
-
-       # clean up
-       rm -f $HOME/.config/hub
+       eval "$HOME/download/hub-linux-amd64-2.2.1/hub pull-request -m "$(printf "[ci skip][TRAVIS] UPDATE [gh-pages/$TRAVIS_BRANCH] @ $TRAVIS_BUILD_NUMBER\n\n$TRAVIS_BUILD_NUMBER\nAutomated Pull Request :shipit:")" -b 'OfficeDev/ews-java-api:gh-pages' -h ${GITHUB_USERNAME}/ews-java-api:gh-pages"
 
        echo "[GH-PAGES] Finished site deployment. Pull request now needs to be merged by humans."
     fi
 fi
+exit 0


### PR DESCRIPTION
script will now also deploy the generated site to gh-pages branch after deploying javadoc and sources to maven central. if one of the mentioned steps fail the script will exit.

Once we generated a gh-page this will enable people to see the actual generated site artifacts and javadoc without executing these steps locally. 