### PR TITLE
fix maven-surefire-report will always be empty

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -376,13 +376,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>${maven-surefire-report-plugin.version}</version>
-                <reportSets>
-                    <reportSet>
-                        <reports>
-                            <report>report-only</report>
-                        </reports>
-                    </reportSet>
-                </reportSets>
             </plugin>
         </plugins>
     </reporting>


### PR DESCRIPTION
looking at the generated `mvn site`  maven-surefire-report will always be empty and does not contain any information because the configuration advises just to create an empty report. Removing the selected lines resolves this.