### PR TITLE
Ewsxmlreaderfix

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsXmlReader.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsXmlReader.java
@@ -472,10 +472,11 @@ public class EwsXmlReader {
         // Element)
         // this.read();
         return elementValue.toString();
+      } else if (this.presentEvent.isEndElement()) {
+        return "";
       } else {
         throw new ServiceXmlDeserializationException(
-          getReadValueErrMsg("Could not find " + XmlNodeType.getString(XmlNodeType.CHARACTERS))
-        );
+            getReadValueErrMsg("Could not find " + XmlNodeType.getString(XmlNodeType.CHARACTERS)));
       }
     } else if (this.presentEvent.getEventType() == XmlNodeType.CHARACTERS
         && this.presentEvent.isCharacters()) {


### PR DESCRIPTION
ref. #337

> I got the following exception when the subject of one email subject is : =?iso-8859-1?Q?=00?=
and empty appointments got the same error, I think it is also a solution to #262 
```
microsoft.exchange.webservices.data.EWSHttpException: Connection not established
     at microsoft.exchange.webservices.data.HttpClientWebRequest.throwIfConnIsNull(Unknown Source)
     at microsoft.exchange.webservices.data.HttpClientWebRequest.getResponseHeaders(Unknown Source)
     at microsoft.exchange.webservices.data.ExchangeServiceBase.processHttpResponseHeaders(Unknown Source)
     at microsoft.exchange.webservices.data.SimpleServiceRequestBase.internalExecute(Unknown Source)
     at microsoft.exchange.webservices.data.MultiResponseServiceRequest.execute(Unknown Source)
     at microsoft.exchange.webservices.data.ExchangeService.findItems(Unknown Source)
     at microsoft.exchange.webservices.data.ExchangeService.findItems(Unknown Source)
```
> @atamer