### PR TITLE
Get server time zones

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsUtilities.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsUtilities.java
@@ -235,7 +235,7 @@ public final class EwsUtilities {
   private static final Pattern PATTERN_DAY = Pattern.compile("(\\d+)D");
   private static final Pattern PATTERN_HOUR = Pattern.compile("(\\d+)H");
   private static final Pattern PATTERN_MINUTES = Pattern.compile("(\\d+)M");
-  private static final Pattern PATTERN_SECONDS = Pattern.compile("(\\d+).");
+  private static final Pattern PATTERN_SECONDS = Pattern.compile("(\\d+)\\."); // Need to escape dot, otherwise it matches any char
   private static final Pattern PATTERN_MILLISECONDS = Pattern.compile("(\\d+)S");
 
 
@@ -871,15 +871,12 @@ public final class EwsUtilities {
     // TODO: Need to check whether this should be the equivalent or not
     Matcher m = PATTERN_TIME_SPAN.matcher(xsDuration);
     boolean negative = false;
-    LOG.debug(m.find());
     if (m.find()) {
       negative = true;
     }
-    LOG.debug(m.group());
 
     // Year
     m = PATTERN_YEAR.matcher(xsDuration);
-    LOG.debug(m.find());
     int year = 0;
     if (m.find()) {
       year = Integer.parseInt(m.group().substring(0,
@@ -888,7 +885,6 @@ public final class EwsUtilities {
 
     // Month
     m = PATTERN_MONTH.matcher(xsDuration);
-    LOG.debug(m.find());
     int month = 0;
     if (m.find()) {
       month = Integer.parseInt(m.group().substring(0,
@@ -897,7 +893,6 @@ public final class EwsUtilities {
 
     // Day
     m = PATTERN_DAY.matcher(xsDuration);
-    LOG.debug(m.find());
     int day = 0;
     if (m.find()) {
       day = Integer.parseInt(m.group().substring(0,
@@ -906,7 +901,6 @@ public final class EwsUtilities {
 
     // Hour
     m = PATTERN_HOUR.matcher(xsDuration);
-    LOG.debug(m.find());
     int hour = 0;
     if (m.find()) {
       hour = Integer.parseInt(m.group().substring(0,
@@ -915,7 +909,6 @@ public final class EwsUtilities {
 
     // Minute
     m = PATTERN_MINUTES.matcher(xsDuration);
-    LOG.debug(m.find());
     int minute = 0;
     if (m.find()) {
       minute = Integer.parseInt(m.group().substring(0,
@@ -924,7 +917,6 @@ public final class EwsUtilities {
 
     // Seconds
     m = PATTERN_SECONDS.matcher(xsDuration);
-    LOG.debug(m.find());
     int seconds = 0;
     if (m.find()) {
       seconds = Integer.parseInt(m.group().substring(0,
@@ -933,7 +925,6 @@ public final class EwsUtilities {
 
     int milliseconds = 0;
     m = PATTERN_MILLISECONDS.matcher(xsDuration);
-    LOG.debug(m.find());
     if (m.find()) {
       // Only allowed 4 digits of precision
       if (m.group().length() > 5) {

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
@@ -30,10 +30,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.EnumSet;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.TimeZone;
 
 import microsoft.exchange.webservices.data.autodiscover.AutodiscoverService;
@@ -99,6 +101,7 @@ import microsoft.exchange.webservices.data.core.request.GetItemRequestForLoad;
 import microsoft.exchange.webservices.data.core.request.GetPasswordExpirationDateRequest;
 import microsoft.exchange.webservices.data.core.request.GetRoomListsRequest;
 import microsoft.exchange.webservices.data.core.request.GetRoomsRequest;
+import microsoft.exchange.webservices.data.core.request.GetServerTimeZonesRequest;
 import microsoft.exchange.webservices.data.core.request.GetUserAvailabilityRequest;
 import microsoft.exchange.webservices.data.core.request.GetUserConfigurationRequest;
 import microsoft.exchange.webservices.data.core.request.GetUserOofSettingsRequest;
@@ -132,6 +135,7 @@ import microsoft.exchange.webservices.data.core.response.GetAttachmentResponse;
 import microsoft.exchange.webservices.data.core.response.GetDelegateResponse;
 import microsoft.exchange.webservices.data.core.response.GetFolderResponse;
 import microsoft.exchange.webservices.data.core.response.GetItemResponse;
+import microsoft.exchange.webservices.data.core.response.GetServerTimeZonesResponse;
 import microsoft.exchange.webservices.data.core.response.MoveCopyFolderResponse;
 import microsoft.exchange.webservices.data.core.response.MoveCopyItemResponse;
 import microsoft.exchange.webservices.data.core.response.ServiceResponse;
@@ -3928,58 +3932,51 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
   public void setExchange2007CompatibilityMode(boolean value) {
     this.exchange2007CompatibilityMode = value;
   }
-
+  
   /**
    * Retrieves the definitions of the specified server-side time zones.
    *
    * @param timeZoneIds the time zone ids
    * @return A Collection containing the definitions of the specified time
    * zones.
+ * @throws Exception 
    */
   public Collection<TimeZoneDefinition> getServerTimeZones(
-      Iterable<String> timeZoneIds) {
-    Date today = new Date();
+      Iterable<String> timeZoneIds) throws Exception {
+    Map<String, TimeZoneDefinition> timeZoneMap = new HashMap<String, TimeZoneDefinition>();
+    
+    GetServerTimeZonesRequest request = new GetServerTimeZonesRequest(this);
+	ServiceResponseCollection<GetServerTimeZonesResponse> responses = request.execute();
+	for (GetServerTimeZonesResponse response : responses) {
+		for (TimeZoneDefinition tzd : response.getTimeZones()) {
+			timeZoneMap.put(tzd.getId(), tzd);
+		}
+	}
+   
     Collection<TimeZoneDefinition> timeZoneList = new ArrayList<TimeZoneDefinition>();
+
     for (String timeZoneId : timeZoneIds) {
-      TimeZoneDefinition timeZoneDefinition = new TimeZoneDefinition();
-      timeZoneList.add(timeZoneDefinition);
-      TimeZone timeZone = TimeZone.getTimeZone(timeZoneId);
-      timeZoneDefinition.id = timeZone.getID();
-      timeZoneDefinition.name = timeZone.getDisplayName(timeZone
-          .inDaylightTime(today), TimeZone.LONG);
-			/*
-			 * String shortName =
-			 * timeZone.getDisplayName(timeZone.inDaylightTime(today),
-			 * TimeZone.SHORT); String longName =
-			 * timeZone.getDisplayName(timeZone.inDaylightTime(today),
-			 * TimeZone.LONG); int rawOffset = timeZone.getRawOffset(); int hour
-			 * = rawOffset / (60*60*1000); int min = Math.abs(rawOffset /
-			 * (60*1000)) % 60; boolean hasDST = timeZone.useDaylightTime();
-			 * boolean inDST = timeZone.inDaylightTime(today);
-			 */
+    	timeZoneList.add(timeZoneMap.get(timeZoneId));
     }
 
     return timeZoneList;
   }
-
+  
   /**
    * Retrieves the definitions of all server-side time zones.
    *
    * @return A Collection containing the definitions of the specified time
    * zones.
+ * @throws Exception 
    */
-  public Collection<TimeZoneDefinition> getServerTimeZones() {
-    Date today = new Date();
-    Collection<TimeZoneDefinition> timeZoneList = new ArrayList<TimeZoneDefinition>();
-    for (String timeZoneId : TimeZone.getAvailableIDs()) {
-      TimeZoneDefinition timeZoneDefinition = new TimeZoneDefinition();
-      timeZoneList.add(timeZoneDefinition);
-      TimeZone timeZone = TimeZone.getTimeZone(timeZoneId);
-      timeZoneDefinition.id = timeZone.getID();
-      timeZoneDefinition.name = timeZone.getDisplayName(timeZone
-          .inDaylightTime(today), TimeZone.LONG);
-    }
-
+  public Collection<TimeZoneDefinition> getServerTimeZones() throws Exception {
+	  GetServerTimeZonesRequest request = new GetServerTimeZonesRequest(this);
+	  Collection<TimeZoneDefinition> timeZoneList = new ArrayList<TimeZoneDefinition>();
+	  ServiceResponseCollection<GetServerTimeZonesResponse> responses = request.execute();
+	  for (GetServerTimeZonesResponse response : responses) {
+		  timeZoneList.addAll(response.getTimeZones());
+	  }
+   
     return timeZoneList;
   }
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/GetServerTimeZonesRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/GetServerTimeZonesRequest.java
@@ -38,7 +38,7 @@ import javax.xml.stream.XMLStreamException;
 /**
  * Represents a GetServerTimeZones request.
  */
-class GetServerTimeZonesRequest extends
+public final class GetServerTimeZonesRequest extends
     MultiResponseServiceRequest<GetServerTimeZonesResponse> {
 
   /**
@@ -65,7 +65,7 @@ class GetServerTimeZonesRequest extends
    * @param service the service
    * @throws Exception
    */
-  protected GetServerTimeZonesRequest(ExchangeService service)
+  public GetServerTimeZonesRequest(ExchangeService service)
       throws Exception {
     super(service, ServiceErrorHandling.ThrowOnError);
   }

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/time/TimeZoneDefinition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/time/TimeZoneDefinition.java
@@ -29,6 +29,7 @@ import microsoft.exchange.webservices.data.core.XmlAttributeNames;
 import microsoft.exchange.webservices.data.core.XmlElementNames;
 import microsoft.exchange.webservices.data.core.enumeration.misc.ExchangeVersion;
 import microsoft.exchange.webservices.data.core.enumeration.misc.XmlNamespace;
+import microsoft.exchange.webservices.data.core.enumeration.property.time.DayOfTheWeek;
 import microsoft.exchange.webservices.data.core.exception.service.local.InvalidOrUnsupportedTimeZoneDefinitionException;
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceLocalException;
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceXmlSerializationException;
@@ -114,13 +115,18 @@ public class TimeZoneDefinition extends ComplexProperty implements Comparator<Ti
     if (x == y) {
       return 0;
     } else if (x != null && y != null) {
-      final AbsoluteDateTransition firstTransition = (AbsoluteDateTransition) x;
-      final AbsoluteDateTransition secondTransition = (AbsoluteDateTransition) y;
+      if (x instanceof AbsoluteDateTransition && y instanceof AbsoluteDateTransition) {
+        final AbsoluteDateTransition firstTransition = (AbsoluteDateTransition) x;
+        final AbsoluteDateTransition secondTransition = (AbsoluteDateTransition) y;
 
-      final Date firstDateTime = firstTransition.getDateTime();
-      final Date secondDateTime = secondTransition.getDateTime();
+        final Date firstDateTime = firstTransition.getDateTime();
+        final Date secondDateTime = secondTransition.getDateTime();
 
-      return firstDateTime.compareTo(secondDateTime);
+        return firstDateTime.compareTo(secondDateTime);
+
+      } else if (y instanceof TimeZoneTransition) {
+        return 1;
+      }
     } else if (y == null) {
       return 1;
     }

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/time/TimeZoneTransition.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/time/TimeZoneTransition.java
@@ -121,18 +121,22 @@ public class TimeZoneTransition extends ComplexProperty {
       String targetId = reader.readElementValue();
       if (targetKind.equals(PeriodTarget)) {
         if (!this.timeZoneDefinition.getPeriods().containsKey(targetId)) {
-          this.targetPeriod = this.timeZoneDefinition.getPeriods()
-              .get(targetId);
+         
           throw new ServiceLocalException(String.format(
               "Invalid transition. A period with the specified Id couldn't be found: %s", targetId));
+        } else {
+        	 this.targetPeriod = this.timeZoneDefinition.getPeriods()
+                     .get(targetId);
         }
       } else if (targetKind.equals(GroupTarget)) {
         if (!this.timeZoneDefinition.getTransitionGroups().containsKey(
             targetId)) {
-          this.targetGroup = this.timeZoneDefinition
-              .getTransitionGroups().get(targetId);
+         
           throw new ServiceLocalException(String.format(
               "Invalid transition. A transition group with the specified ID couldn't be found: %s", targetId));
+        } else {
+        	 this.targetGroup = this.timeZoneDefinition
+                     .getTransitionGroups().get(targetId);
         }
       } else {
         throw new ServiceLocalException("The time zone transition target isn't supported.");
@@ -159,7 +163,7 @@ public class TimeZoneTransition extends ComplexProperty {
     if (this.targetPeriod != null) {
       writer.writeAttributeValue(XmlAttributeNames.Kind, PeriodTarget);
       writer.writeValue(this.targetPeriod.getId(), XmlElementNames.To);
-    } else {
+    } else if (this.targetGroup != null) {
       writer.writeAttributeValue(XmlAttributeNames.Kind, GroupTarget);
       writer.writeValue(this.targetGroup.getId(), XmlElementNames.To);
     }

--- a/src/test/java/microsoft/exchange/webservices/data/property/complex/TimeZoneTransitionCompareTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/property/complex/TimeZoneTransitionCompareTest.java
@@ -1,0 +1,133 @@
+/*
+ * The MIT License Copyright (c) 2012 Microsoft Corporation
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package microsoft.exchange.webservices.data.property.complex;
+
+import static org.mockito.Mockito.doReturn;
+
+import java.util.Date;
+
+import microsoft.exchange.webservices.data.property.complex.time.AbsoluteDateTransition;
+import microsoft.exchange.webservices.data.property.complex.time.TimeZoneDefinition;
+import microsoft.exchange.webservices.data.property.complex.time.TimeZoneTransition;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+@RunWith(JUnit4.class)
+public class TimeZoneTransitionCompareTest {
+
+  @Test
+  public void testAbsoluteDateTransitionsEqual() {
+    TimeZoneDefinition timeZoneDefinition = new TimeZoneDefinition();
+
+    Date date = new Date();
+
+    AbsoluteDateTransition first = Mockito.mock(AbsoluteDateTransition.class);
+    AbsoluteDateTransition second = Mockito.mock(AbsoluteDateTransition.class);
+
+    doReturn(date).when(first).getDateTime();
+    doReturn(date).when(second).getDateTime();
+
+    Assert.assertEquals(0, timeZoneDefinition.compare(first, second));
+  }
+
+  @Test
+  public void testAbsoluteDateTransitionsLess() {
+    TimeZoneDefinition timeZoneDefinition = new TimeZoneDefinition();
+
+    Date date1 = new Date();
+    Date date2 = new Date(date1.getTime() + 1);
+    
+    AbsoluteDateTransition first = Mockito.mock(AbsoluteDateTransition.class);
+    AbsoluteDateTransition second = Mockito.mock(AbsoluteDateTransition.class);
+
+    doReturn(date1).when(first).getDateTime();
+    doReturn(date2).when(second).getDateTime();
+
+    Assert.assertEquals(-1, timeZoneDefinition.compare(first, second));
+  }
+
+  @Test
+  public void testAbsoluteDateTransitionsGreater() {
+    TimeZoneDefinition timeZoneDefinition = new TimeZoneDefinition();
+
+    Date date1 = new Date();
+    Date date2 = new Date(date1.getTime() - 1);
+    
+    AbsoluteDateTransition first = Mockito.mock(AbsoluteDateTransition.class);
+    AbsoluteDateTransition second = Mockito.mock(AbsoluteDateTransition.class);
+
+    doReturn(date1).when(first).getDateTime();
+    doReturn(date2).when(second).getDateTime();
+
+    Assert.assertEquals(1, timeZoneDefinition.compare(first, second));
+  }
+
+  @Test
+  public void testAbsoluteDateTransitionAndTimeZoneTransition() {
+    TimeZoneDefinition timeZoneDefinition = new TimeZoneDefinition();
+
+    Date date1 = new Date();
+    
+    AbsoluteDateTransition first = Mockito.mock(AbsoluteDateTransition.class);
+    TimeZoneTransition second = Mockito.mock(TimeZoneTransition.class);
+
+    doReturn(date1).when(first).getDateTime();
+
+    Assert.assertEquals(1, timeZoneDefinition.compare(first, second));
+  }
+
+  @Test
+  public void testAbsoluteDateTransitionAndNull() {
+    TimeZoneDefinition timeZoneDefinition = new TimeZoneDefinition();
+   
+    Date date1 = new Date();   
+    AbsoluteDateTransition first = Mockito.mock(AbsoluteDateTransition.class);  
+    doReturn(date1).when(first).getDateTime();
+
+    Assert.assertEquals(1, timeZoneDefinition.compare(first, null));
+  }
+
+  @Test
+  public void testNullAndAbsoluteDateTransition() {
+    TimeZoneDefinition timeZoneDefinition = new TimeZoneDefinition();
+    
+    Date date1 = new Date();
+    AbsoluteDateTransition second = Mockito.mock(AbsoluteDateTransition.class);    
+    doReturn(date1).when(second).getDateTime();
+
+    Assert.assertEquals(-1, timeZoneDefinition.compare(null, second));
+  }
+
+  @Test
+  public void testCompareSameObject() {
+    TimeZoneDefinition timeZoneDefinition = new TimeZoneDefinition();
+
+    Date date1 = new Date();    
+    AbsoluteDateTransition first = Mockito.mock(AbsoluteDateTransition.class);
+    doReturn(date1).when(first).getDateTime();
+
+    Assert.assertEquals(0, timeZoneDefinition.compare(first, first));
+  }
+
+}


### PR DESCRIPTION
Changes in pull request:

* EwsUtilities.PATTERN_SECONDS.
Added escape to dot PATTERN_SECONDS, otherwise it matches any char

* EwsUtilities.getXSDurationToTimeSpan()
Deleted all debug logging, because it does not bring any significant debug information and creates 8 x 108 (number of time zones) messages in debug log

* TimeZoneDefinition.compare(final TimeZoneTransition x, final TimeZoneTransition y) 

  * Added type check before compare. Variable x can only be of type AbsoluteDateTransition (RelativeDayOfMonthTransition and AbsoluteDayOfMonthTransition extend AbsoluteDateTransition). 

  * Variable y can be of type TimeZoneTransition, so added corresponding compare case

* TimeZoneTransition.tryReadElementFromXml()
Refactored getting periods and target groups, because method checks if array does not contain object, and then attempts to get this object from array. Now method correctly gets objects from array, if object does not exist in array an exception will be thrown..

* GetServerTimeZonesRequest
Class and constructor visibility is changed to public, in order to create instance of class in ExchangeService.

* ExchangeService
getServerTimeZones(Iterable<String> timeZoneIds) and getServerTimeZones() are refactored to use GetServerTimeZonesRequest
