### PR TITLE
EWSUtilities.getXSDurationToTimeSpan fix

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsUtilities.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsUtilities.java
@@ -50,8 +50,11 @@ import microsoft.exchange.webservices.data.core.exception.service.local.ServiceV
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceVersionException;
 import microsoft.exchange.webservices.data.misc.TimeSpan;
 import microsoft.exchange.webservices.data.property.complex.ItemAttachment;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.joda.time.Period;
+import org.joda.time.format.ISOPeriodFormat;
 
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -230,14 +233,6 @@ public final class EwsUtilities {
   private static final String XML_SCHEMA_DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 
   private static final Pattern PATTERN_TIME_SPAN = Pattern.compile("-P");
-  private static final Pattern PATTERN_YEAR = Pattern.compile("(\\d+)Y");
-  private static final Pattern PATTERN_MONTH = Pattern.compile("(\\d+)M");
-  private static final Pattern PATTERN_DAY = Pattern.compile("(\\d+)D");
-  private static final Pattern PATTERN_HOUR = Pattern.compile("(\\d+)H");
-  private static final Pattern PATTERN_MINUTES = Pattern.compile("(\\d+)M");
-  private static final Pattern PATTERN_SECONDS = Pattern.compile("(\\d+)\\."); // Need to escape dot, otherwise it matches any char
-  private static final Pattern PATTERN_MILLISECONDS = Pattern.compile("(\\d+)S");
-
 
   private EwsUtilities() {
     throw new UnsupportedOperationException();
@@ -875,79 +870,50 @@ public final class EwsUtilities {
       negative = true;
     }
 
-    // Year
-    m = PATTERN_YEAR.matcher(xsDuration);
-    int year = 0;
-    if (m.find()) {
-      year = Integer.parseInt(m.group().substring(0,
-          m.group().indexOf("Y")));
+    // Removing leading '-'
+    if (negative) {
+      xsDuration = xsDuration.replace("-P", "P");
     }
 
-    // Month
-    m = PATTERN_MONTH.matcher(xsDuration);
-    int month = 0;
-    if (m.find()) {
-      month = Integer.parseInt(m.group().substring(0,
-          m.group().indexOf("M")));
-    }
+    Period period = Period.parse(xsDuration, ISOPeriodFormat.standard());
+    int year = period.getYears();
+    int month = period.getMonths();
+    int day = period.getDays();
+    int hour = period.getHours();
+    int minute = period.getMinutes();
+    int seconds = period.getSeconds();
+    int milliseconds = period.getMillis();
 
-    // Day
-    m = PATTERN_DAY.matcher(xsDuration);
-    int day = 0;
-    if (m.find()) {
-      day = Integer.parseInt(m.group().substring(0,
-          m.group().indexOf("D")));
-    }
+    StringBuilder debugMessage = new StringBuilder();
+    debugMessage.append("negative: " + negative);
+    debugMessage.append(" / ");
+    debugMessage.append("year: " + year);
+    debugMessage.append(" / ");
+    debugMessage.append("month: " + month);
+    debugMessage.append(" / ");
+    debugMessage.append("day: " + day);
+    debugMessage.append(" / ");
+    debugMessage.append("hour: " + hour);
+    debugMessage.append(" / ");
+    debugMessage.append("minute: " + minute);
+    debugMessage.append(" / ");
+    debugMessage.append("seconds: " + seconds);
+    debugMessage.append(" / ");
+    debugMessage.append("milliseconds: " + milliseconds);
 
-    // Hour
-    m = PATTERN_HOUR.matcher(xsDuration);
-    int hour = 0;
-    if (m.find()) {
-      hour = Integer.parseInt(m.group().substring(0,
-          m.group().indexOf("H")));
-    }
+    LOG.debug("Parded TimeSpan: " + debugMessage.toString());
 
-    // Minute
-    m = PATTERN_MINUTES.matcher(xsDuration);
-    int minute = 0;
-    if (m.find()) {
-      minute = Integer.parseInt(m.group().substring(0,
-          m.group().indexOf("M")));
-    }
-
-    // Seconds
-    m = PATTERN_SECONDS.matcher(xsDuration);
-    int seconds = 0;
-    if (m.find()) {
-      seconds = Integer.parseInt(m.group().substring(0,
-          m.group().indexOf(".")));
-    }
-
-    int milliseconds = 0;
-    m = PATTERN_MILLISECONDS.matcher(xsDuration);
-    if (m.find()) {
-      // Only allowed 4 digits of precision
-      if (m.group().length() > 5) {
-        milliseconds = Integer.parseInt(m.group().substring(0, 4));
-      } else {
-        seconds = Integer.parseInt(m.group().substring(0,
-            m.group().indexOf("S")));
-      }
-    }
-
-    // Apply conversions of year and months to days.
-    // Year = 365 days
-    // Month = 30 days
     day = day + (year * 365) + (month * 30);
-    // TimeSpan retval = new TimeSpan(day, hour, minute, seconds,
-    // milliseconds);
-    long retval = (((((((day * 24) + hour) * 60) + minute) * 60) +
-        seconds) * 1000) + milliseconds;
+    
+    long retval =
+        day * TimeSpan.DAYS + hour * TimeSpan.HOURS + minute * TimeSpan.MINUTES + seconds
+            * TimeSpan.SECONDS + milliseconds * TimeSpan.MILLISECONDS;
+    
     if (negative) {
       retval = -retval;
     }
-    return new TimeSpan(retval);
 
+    return new TimeSpan(retval);
   }
 
   /**
@@ -969,70 +935,35 @@ public final class EwsUtilities {
       negative = true;
     }
 
-    // Year
-    //    m = Pattern.compile("(\\d+)Y").matcher(xsDuration);
-    //    int year = 0;
-    //    if (m.find()) {
-    //      year = Integer.parseInt(m.group().substring(0,
-    //          m.group().indexOf("Y")));
-    //    }
-
-    // Month
-    //    m = Pattern.compile("(\\d+)M").matcher(xsDuration);
-    //    int month = 0;
-    //    if (m.find()) {
-    //      month = Integer.parseInt(m.group().substring(0,
-    //          m.group().indexOf("M")));
-    //    }
-
-    // Day
-    m = PATTERN_DAY.matcher(xsDuration);
-    long day = 0;
-    if (m.find()) {
-      day = Integer.parseInt(m.group().substring(0,
-          m.group().indexOf("D")));
+    // Removing leading '-'
+    if (negative) {
+      xsDuration = xsDuration.replace("-P", "P");
     }
 
-    // Hour
-    m = PATTERN_HOUR.matcher(xsDuration);
-    int hour = 0;
-    if (m.find()) {
-      hour = Integer.parseInt(m.group().substring(0,
-          m.group().indexOf("H")));
-    }
+    Period period = Period.parse(xsDuration, ISOPeriodFormat.standard());
+    int day = period.getDays();
+    int hour = period.getHours();
+    int minute = period.getMinutes();
+    int seconds = period.getSeconds();
+    int milliseconds = period.getMillis();
 
-    // Minute
-    m = PATTERN_MINUTES.matcher(xsDuration);
-    int minute = 0;
-    if (m.find()) {
-      minute = Integer.parseInt(m.group().substring(0,
-          m.group().indexOf("M")));
-    }
+    StringBuilder debugMessage = new StringBuilder();
+    debugMessage.append("negative: " + negative);
+    debugMessage.append("day: " + day);
+    debugMessage.append(" / ");
+    debugMessage.append("hour: " + hour);
+    debugMessage.append(" / ");
+    debugMessage.append("minute: " + minute);
+    debugMessage.append(" / ");
+    debugMessage.append("seconds: " + seconds);
+    debugMessage.append(" / ");
+    debugMessage.append("milliseconds: " + milliseconds);
 
-    // Seconds
-    m = PATTERN_SECONDS.matcher(xsDuration);
-    int seconds = 0;
-    int milliseconds = 0;
-    m = PATTERN_MILLISECONDS.matcher(xsDuration);
-    if (m.find()) {
-      // Only allowed 4 digits of precision
-      if (m.group().length() > 5) {
-        milliseconds = Integer.parseInt(m.group().substring(0, 4));
-      } else {
-        seconds = Integer.parseInt(m.group().substring(0, m.group().indexOf("S")));
-      }
-    }
-
-    // Apply conversions of year and months to days.
-    // Year = 365 days
-    // Month = 30 days
-    //	day = day + (year * 365) + (month * 30);
-    //TimeSpan retval = new TimeSpan(day, hour, minute, seconds,
-    // milliseconds);
+    LOG.debug("Parded TimeSpan: " + debugMessage.toString());
 
     long retval =
-        day * TimeSpan.DAYS + hour * TimeSpan.HOURS + minute * TimeSpan.MINUTES + seconds * TimeSpan.SECONDS
-            + milliseconds * TimeSpan.MILLISECONDS;
+        day * TimeSpan.DAYS + hour * TimeSpan.HOURS + minute * TimeSpan.MINUTES + seconds
+            * TimeSpan.SECONDS + milliseconds * TimeSpan.MILLISECONDS;
     if (negative) {
       retval = -retval;
     }

--- a/src/test/java/microsoft/exchange/webservices/data/util/TimeSpanUtilsTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/util/TimeSpanUtilsTest.java
@@ -1,0 +1,65 @@
+/*
+ * The MIT License Copyright (c) 2012 Microsoft Corporation
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package microsoft.exchange.webservices.data.util;
+
+import microsoft.exchange.webservices.data.core.EwsUtilities;
+import microsoft.exchange.webservices.data.misc.TimeSpan;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TimeSpanUtilsTest {
+
+  // Tests for EwsUtilities.getXSDurationToTimeSpan()
+
+  private static final String PERIOD_HOURS = "-PT13H";
+  private static final String PERIOD_HOURS_MINUTES = "-PT5H30M";
+  private static final String PERIOD_FULL = "PT2H30M59.0S";
+  private static final String PERIOD_FULL_NEGATIVE = "-PT2H30M59.0S";
+
+
+  @Test
+  public void testPeriodHours() {
+    TimeSpan timeSpan = EwsUtilities.getXSDurationToTimeSpan(PERIOD_HOURS);
+    Assert.assertEquals("-P0DT13H0M0.0S", EwsUtilities.getTimeSpanToXSDuration(timeSpan));
+  }
+
+  @Test
+  public void testPeriodHoursMinutes() {
+    TimeSpan timeSpan = EwsUtilities.getXSDurationToTimeSpan(PERIOD_HOURS_MINUTES);
+    Assert.assertEquals("-P0DT5H30M0.0S", EwsUtilities.getTimeSpanToXSDuration(timeSpan));
+  }
+
+  @Test
+  public void testPeriodFull() {
+    TimeSpan timeSpan = EwsUtilities.getXSDurationToTimeSpan(PERIOD_FULL);
+    Assert.assertEquals("P0DT2H30M59.0S", EwsUtilities.getTimeSpanToXSDuration(timeSpan));
+  }
+
+  @Test
+  public void testPeriodFullNegative() {
+    TimeSpan timeSpan = EwsUtilities.getXSDurationToTimeSpan(PERIOD_FULL_NEGATIVE);
+    Assert.assertEquals("-P0DT2H30M59.0S", EwsUtilities.getTimeSpanToXSDuration(timeSpan));
+  }
+
+}


### PR DESCRIPTION
* This pull request fixes the problem with wrong parsing of Bias in Period. 

* Fixes  #357, #398 and #343 

* Problem: 
 * TimeSpan for this one -PT3H30M will be parsed as:
```
negative true
year 0
month 30
day 0
hour 3
minute 30
seconds 0
```
* The big M for months and minutes seems to be correct according to ISO 8601 and the only difference is 'T' in the middle. For example this one P1Y2M10DT2H30M is a correct Time interval.

* Fix:
 * Two method are refactored getXSDurationToTimeSpan() and getXSDurationToTimeSpanValue().
 * For parsing of TimeSpan, an Joda-Time Period is now used instead of row Java Regex.
 * Period.parse() can automatically parse any value in form ```P1Y2M10DT2H30M```, except of leading '-' symbol. For parsing '-' Java Regex is still used. 

* Test
 * Corresponding tests are added to new class TimeSpanUtilsTest

