### PR TITLE
Only attempt to set dns server if provided

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/dns/DnsClient.java
+++ b/src/main/java/microsoft/exchange/webservices/data/dns/DnsClient.java
@@ -43,6 +43,23 @@ import java.util.List;
 public class DnsClient {
 
   /**
+   * Set up the environment used to construct the DirContext.
+   *
+   * @param dnsServerAddress
+   * @return
+   */
+  static Hashtable<String, String> getEnv(String dnsServerAddress) {
+    // Set up environment for creating initial context
+    Hashtable<String, String> env = new Hashtable<String, String>();
+    env.put("java.naming.factory.initial",
+            "com.sun.jndi.dns.DnsContextFactory");
+    if(dnsServerAddress != null && !dnsServerAddress.isEmpty()) {
+      env.put("java.naming.provider.url", "dns://" + dnsServerAddress);
+    }
+    return env;
+  }
+
+  /**
    * Performs Dns query.
    *
    * @param <T>              the generic type
@@ -58,15 +75,8 @@ public class DnsClient {
 
     List<T> dnsRecordList = new ArrayList<T>();
     try {
-
-      // Set up environment for creating initial context
-      Hashtable<String, String> env = new Hashtable<String, String>();
-      env.put("java.naming.factory.initial",
-          "com.sun.jndi.dns.DnsContextFactory");
-      env.put("java.naming.provider.url", "dns://" + dnsServerAddress);
-
       // Create initial context
-      DirContext ictx = new InitialDirContext(env);
+      DirContext ictx = new InitialDirContext(getEnv(dnsServerAddress));
 
       // Retrieve SRV record context attribute for the specified domain
       Attributes contextAttributes = ictx.getAttributes(domain,

--- a/src/test/java/microsoft/exchange/webservices/data/dns/DnsClientTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/dns/DnsClientTest.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ * Copyright (c) 2012 Microsoft Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package microsoft.exchange.webservices.data.dns;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Hashtable;
+
+public class DnsClientTest {
+  @Test public void getEnvShouldSetNaming() {
+    Hashtable<String, String> env = DnsClient.getEnv("");
+    Assert.assertEquals(env.get("java.naming.factory.initial"),
+                        "com.sun.jndi.dns.DnsContextFactory");
+  }
+
+  @Test public void getEnvShouldNotSetProviderUrl() throws Exception {
+    Hashtable<String, String> env = DnsClient.getEnv("");
+    Assert.assertFalse(env.containsKey("java.naming.provider.url"));
+    env = DnsClient.getEnv(null);
+    Assert.assertFalse(env.containsKey("java.naming.provider.url"));
+  }
+
+  @Test public void getEnvShoulSetProviderUrl() throws Exception {
+    Hashtable<String, String> env = DnsClient.getEnv("1.1.1.1");
+    Assert.assertEquals(env.get("java.naming.provider.url"), "dns://1.1.1.1");
+  }
+}


### PR DESCRIPTION
This patch simply avoids throwing an NPE if the dnsServerAddress is not provided. This allows fallback to the system resolver.