### PR TITLE
AbsoluteDate and Time by TimeChange fix

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/TimeChange.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/TimeChange.java
@@ -32,11 +32,15 @@ import microsoft.exchange.webservices.data.core.enumeration.misc.XmlNamespace;
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceXmlSerializationException;
 import microsoft.exchange.webservices.data.misc.Time;
 import microsoft.exchange.webservices.data.misc.TimeSpan;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import java.text.SimpleDateFormat;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.TimeZone;
+
+import javax.xml.bind.DatatypeConverter;
 
 /**
  * Represents a change of time for a time zone.
@@ -217,16 +221,13 @@ public final class TimeChange extends ComplexProperty {
       return true;
     } else if (reader.getLocalName().equalsIgnoreCase(
         XmlElementNames.AbsoluteDate)) {
-      SimpleDateFormat sdfin = new SimpleDateFormat(
-          "yyyy-MM-dd'T'HH:mm:ss");
-      Date tempDate = sdfin.parse(reader.readElementValue());
-      this.absoluteDate = tempDate;
+      Calendar cal = DatatypeConverter.parseDate(reader.readElementValue());
+      cal.setTimeZone(TimeZone.getTimeZone("UTC"));
+      this.absoluteDate = cal.getTime();
       return true;
     } else if (reader.getLocalName().equalsIgnoreCase(XmlElementNames.Time)) {
-      SimpleDateFormat sdfin = new SimpleDateFormat(
-          "yyyy-MM-dd'T'HH:mm:ss");
-      Date tempDate = sdfin.parse(reader.readElementValue());
-      this.time = new Time(tempDate);
+      Calendar cal = DatatypeConverter.parseTime(reader.readElementValue());
+      this.time = new Time(cal.getTime());
       return true;
     } else {
       return false;

--- a/src/test/java/microsoft/exchange/webservices/data/property/complex/TimeChangeTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/property/complex/TimeChangeTest.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License Copyright (c) 2012 Microsoft Corporation
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+package microsoft.exchange.webservices.data.property.complex;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+import javax.xml.bind.DatatypeConverter;
+
+import microsoft.exchange.webservices.data.core.EwsUtilities;
+import microsoft.exchange.webservices.data.misc.Time;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class TimeChangeTest {
+
+  private static String time = "03:00:00";
+  private static String time_fail1 = "21:32";
+  private static String time_fail2 = "25:25:10";
+  private static String time_fail3 = "-10:00:00";
+
+  private static String dateUTC = "2001-10-27Z";
+  private static String date_fail1 = "2001-10-32";
+  private static String date_fail2 = "2001-13-26+02:00";
+  private static String date_fail3 = "01-10-26";
+
+  @Test
+  public void testDateUTC() {
+    Assert.assertEquals("2001-10-27Z", testDate(dateUTC));
+  }
+
+  private String testDate(String value) {
+    Calendar cal = DatatypeConverter.parseDate(value);
+    cal.setTimeZone(TimeZone.getTimeZone("UTC"));
+    String XSDate = EwsUtilities.dateTimeToXSDate(cal.getTime());
+    return XSDate;
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDateFail1() {
+    testDate(date_fail1);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDateFail2() {
+    testDate(date_fail2);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testDateFail3() {
+    testDate(date_fail3);
+  }
+
+  private String testTime(String value) {
+    Calendar cal = DatatypeConverter.parseTime(value);
+    Time time = new Time(cal.getTime());
+    return time.toXSTime();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testTimeFail1() {
+    testTime(time_fail1);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testTimeFail2() {
+    testTime(time_fail2);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testTimeFail3() {
+    testTime(time_fail3);
+  }
+
+  @Test
+  public void testTimeValues() {
+    Assert.assertEquals("{0:00}:{1:00}:{2:00},3,0,0", testTime(time));
+  }
+
+}


### PR DESCRIPTION
Pull request to fix bug in parsing AbsoluteDate and Time in TimeChange class

Bug:
* The method tryReadElementFromXml(EwsServiceXmlReader reader) tries to read XML elements AbsoluteDate and Time using  
```
SimpleDateFormat sdfin = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
```

Error:
 * Then parsing of Exchange 2007 SP1 server response with MeetingTimeZone element causes following error:
```
microsoft.exchange.webservices.data.core.exception.service.remote.ServiceRequestException: The request failed. Unparseable date: "03:00:00"
```

Fix Description:
* According to TimeChangeType https://msdn.microsoft.com/en-us/library/office/aa566047%28v=exchg.150%29.aspx and http://www.w3schools.com/schema/schema_dtypes_date.asp:
 * Time should be of type xs:time. See https://msdn.microsoft.com/en-us/library/office/aa565027%28v=exchg.150%29.aspx and for examples http://books.xmlschemata.org/relaxng/ch19-77311.html). 
 * The correct value returned by server will be  ```<t:Time>02:00:00</t:Time>```
 * AbsoluteDate should be of type xs:date value see https://msdn.microsoft.com/en-us/library/office/aa581577%28v=exchg.150%29.aspx and for examples http://books.xmlschemata.org/relaxng/ch19-77041.html

* The parsing using SimpleDateFormat was replaced with DatatypeConverter (http://docs.oracle.com/javase/7/docs/api/javax/xml/bind/DatatypeConverter.html), which can parse all forms of xs:date and xs:time. 

* Because EwsUtilities,dateTimeToXSDate() returns date using UTC Formatter, time zone of parsed calendar is also set to UTC, to avoid platform depend behaviour (different default Time Zones on system)

* Corresponding tests are also added.