### PR TITLE
Make ExchangeService more or less thread safe

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
@@ -389,7 +389,7 @@ public class AutodiscoverService extends ExchangeServiceBase
     HttpWebRequest request = null;
 
     try {
-      request = new HttpClientWebRequest(httpClient, httpContext);
+      request = new HttpClientWebRequest(getHttpClient(), createHttpClientContext());
       request.setProxy(getWebProxy());
 
       try {
@@ -1509,7 +1509,7 @@ public class AutodiscoverService extends ExchangeServiceBase
 
       HttpWebRequest request = null;
       try {
-        request = new HttpClientWebRequest(httpClient, httpContext);
+        request = new HttpClientWebRequest(getHttpClient(), createHttpClientContext());
         request.setProxy(getWebProxy());
 
         try {

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
@@ -3573,7 +3573,7 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
         ExchangeVersion.Exchange2007_SP1,
         validateRedirectionUrlCallback);
 
-    this.setUrl(this.adjustServiceUriFromCredentials(exchangeServiceUrl));
+    setUrl(this.adjustServiceUriFromCredentials(exchangeServiceUrl));
   }
 
   /**
@@ -3741,11 +3741,11 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
   public HttpWebRequest prepareHttpWebRequest()
       throws ServiceLocalException, URISyntaxException {
     try {
-      this.url = this.adjustServiceUriFromCredentials(this.getUrl());
+      setUrl(this.adjustServiceUriFromCredentials(this.getUrl()));
     } catch (Exception e) {
       LOG.error(e);
     }
-    return this.prepareHttpWebRequestForUrl(url, this
+    return this.prepareHttpWebRequestForUrl(getUrl(), this
         .getAcceptGzipEncoding(), true);
   }
 
@@ -3759,11 +3759,11 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
   public HttpWebRequest prepareHttpPoolingWebRequest()
 	      throws ServiceLocalException, URISyntaxException {
 	    try {
-	      this.url = this.adjustServiceUriFromCredentials(this.getUrl());
+	      setUrl(this.adjustServiceUriFromCredentials(this.getUrl()));
 	    } catch (Exception e) {
 	      LOG.error(e);
 	    }
-	    return this.prepareHttpPoolingWebRequestForUrl(url, this
+	    return this.prepareHttpPoolingWebRequestForUrl(getUrl(), this
 	        .getAcceptGzipEncoding(), true);
 	  }
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
@@ -208,7 +208,7 @@ public abstract class ExchangeServiceBase implements Closeable {
   public void setMaximumPoolingConnections(int maximumPoolingConnections) {
     if (maximumPoolingConnections < 1)
       throw new IllegalArgumentException("maximumPoolingConnections must be 1 or greater");
-    if(httpPoolingClient!=null){
+    if (httpPoolingClient != null) {
     	throw new IllegalStateException("Cannot change the maximumPoolingConnections setting after a request has been made");
     }
     this.maximumPoolingConnections = maximumPoolingConnections;
@@ -262,7 +262,7 @@ public abstract class ExchangeServiceBase implements Closeable {
           } catch (IOException e) {
             LOG.debug(e);
           }
-          httpPoolingClient=null;
+          httpPoolingClient = null;
     	}
       }
     }

--- a/src/main/java/microsoft/exchange/webservices/data/core/WebProxy.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/WebProxy.java
@@ -45,7 +45,7 @@ public class WebProxy {
    * @param port proxy port.
    */
   public WebProxy(String host, int port) {
-    this(host,port,null);
+    this(host, port, null);
   }
 
   /**
@@ -54,7 +54,7 @@ public class WebProxy {
    * @param host proxy host.
    */
   public WebProxy(String host) {
-    this(host,80,null);
+    this(host, 80, null);
   }
 
   /**
@@ -64,7 +64,7 @@ public class WebProxy {
    * @param credentials the credential to use for the proxy.
    */
   public WebProxy(String host, WebProxyCredentials credentials) {
-    this(host,80,credentials);
+    this(host, 80, credentials);
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/core/WebProxy.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/WebProxy.java
@@ -31,11 +31,11 @@ import microsoft.exchange.webservices.data.credential.WebProxyCredentials;
  */
 public class WebProxy {
 
-  private String host;
+  private final String host;
 
-  private int port;
+  private final int port;
 
-  private WebProxyCredentials credentials;
+  private final WebProxyCredentials credentials;
 
 
   /**
@@ -45,8 +45,7 @@ public class WebProxy {
    * @param port proxy port.
    */
   public WebProxy(String host, int port) {
-    this.host = host;
-    this.port = port;
+    this(host,port,null);
   }
 
   /**
@@ -55,8 +54,7 @@ public class WebProxy {
    * @param host proxy host.
    */
   public WebProxy(String host) {
-    this.host = host;
-    this.port = 80;
+    this(host,80,null);
   }
 
   /**
@@ -66,8 +64,7 @@ public class WebProxy {
    * @param credentials the credential to use for the proxy.
    */
   public WebProxy(String host, WebProxyCredentials credentials) {
-    this.host = host;
-    this.credentials = credentials;
+    this(host,80,credentials);
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/credential/WebProxyCredentials.java
+++ b/src/main/java/microsoft/exchange/webservices/data/credential/WebProxyCredentials.java
@@ -23,13 +23,13 @@
 
 package microsoft.exchange.webservices.data.credential;
 
-public class WebProxyCredentials {
+public final class WebProxyCredentials {
 
-  private String username;
+  private final String username;
 
-  private String password;
+  private final String password;
 
-  private String domain;
+  private final String domain;
 
   public WebProxyCredentials(String username, String password, String domain) {
     this.username = username;


### PR DESCRIPTION
HttpClientContext isn't thread safe, and isn't meant for reuse, so create a new one each time it's needed
Use a shared cookied store per ExchangeService instance, clearing when necessary
ExchangeService is now thread safe, as long as certain properties (meant to be only set once at initialization time) are not changed oftentime while ExchangeService is being used
Safely manage HttpClient instances so they're lazy initialized used double checked locking
Made fields that can be final final, which improve understability and encourages thread safe design

Resolves gh-371