### PR TITLE
Web Proxy set

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
@@ -379,7 +379,7 @@ public abstract class ExchangeServiceBase implements Closeable {
     request.setAllowAutoRedirect(allowAutoRedirect);
     request.setAcceptGzipEncoding(acceptGzipEncoding);
     request.setHeaders(getHttpHeaders());
-
+    request.setProxy(getWebProxy());
     prepareCredentials(request);
 
     request.prepareConnection();


### PR DESCRIPTION
While initializing ExchangeService object, I call method exchangeService.setWebProxy passing https proxy details. In the class ExchangeServiceBase it was not getting set.