### PR TITLE
Add checkstyle as part of the Maven build to ensure coding standards compliance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <javadoc.doclint.param/>
 
         <!--  Dependencies [BUILD]:  -->
+        <maven-checkstyle-plugin.version>2.16</maven-checkstyle-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
@@ -98,6 +99,34 @@
             <properties>
                 <javadoc.doclint.param>-Xdoclint:none</javadoc.doclint.param>
             </properties>
+        </profile>
+        <profile>
+            <!-- maven-checkstyle-plugin required Java 7 or later -->
+            <id>java-7-or-later-profile</id>
+            <activation>
+                <jdk>[1.7,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>${maven-checkstyle-plugin.version}</version>
+                    <configuration>
+                    <failsOnError>true</failsOnError>
+                        <configLocation>google_checks.xml</configLocation>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>checkstyle</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>release-sign-artifacts</id>


### PR DESCRIPTION
This change runs checkstyle as part of the "verify" phase of the Maven life cycle.

Running checkstyle as part of the build process ensures that the code is always compliant with the coding standards.

See #4 for some earlier, relevant discussion.