### PR TITLE
Use IOUtils.closeQuietly instead of reimplementing that method in each location

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <commons-logging.version>1.2</commons-logging.version>
         <joda-time.version>2.8</joda-time.version>
         <commons-lang3.version>3.4</commons-lang3.version>
+        <commons-io.version>2.4</commons-io.version>
         <!--  Dependencies [TEST]:  -->
         <junit.version>4.12</junit.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
@@ -173,6 +174,12 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <version>${httpcore.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons-io.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
@@ -56,6 +56,7 @@ import microsoft.exchange.webservices.data.credential.ExchangeCredentials;
 import microsoft.exchange.webservices.data.misc.EwsTraceListener;
 import microsoft.exchange.webservices.data.misc.ITraceListener;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.client.AuthenticationStrategy;
@@ -264,19 +265,8 @@ public abstract class ExchangeServiceBase implements Closeable {
 
   @Override
   public void close() {
-    try {
-      httpClient.close();
-    } catch (IOException e) {
-      LOG.debug(e);
-    }
-
-    if (httpPoolingClient != null) {
-      try {
-        httpPoolingClient.close();
-      } catch (IOException e) {
-        LOG.debug(e);
-      }
-    }
+    IOUtils.closeQuietly(httpClient);
+    IOUtils.closeQuietly(httpPoolingClient);
   }
 
   // Event handlers

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/HangingServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/HangingServiceRequestBase.java
@@ -36,6 +36,7 @@ import microsoft.exchange.webservices.data.core.exception.service.remote.Service
 import microsoft.exchange.webservices.data.core.exception.xml.XmlException;
 import microsoft.exchange.webservices.data.misc.HangingTraceStream;
 import microsoft.exchange.webservices.data.security.XmlNodeType;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -241,14 +242,7 @@ public abstract class HangingServiceRequestBase<T> extends ServiceRequestBase<T>
       // Stream is closed, so disconnect.
       this.disconnect(HangingRequestDisconnectReason.Exception, ex);
     } finally {
-      if (responseCopy != null) {
-        try {
-          responseCopy.close();
-          responseCopy = null;
-        } catch (Exception ex) {
-          LOG.error(ex);
-        }
-      }
+      IOUtils.closeQuietly(responseCopy);
     }
   }
 
@@ -272,11 +266,7 @@ public abstract class HangingServiceRequestBase<T> extends ServiceRequestBase<T>
    */
   public void disconnect() {
     synchronized (this) {
-      try {
-        this.response.close();
-      } catch (IOException e) {
-        // Ignore exception on disconnection
-      }
+      IOUtils.closeQuietly(this.response);
       this.disconnect(HangingRequestDisconnectReason.UserInitiated, null);
     }
   }
@@ -289,11 +279,7 @@ public abstract class HangingServiceRequestBase<T> extends ServiceRequestBase<T>
    */
   public void disconnect(HangingRequestDisconnectReason reason, Exception exception) {
     if (this.isConnected()) {
-      try {
-        this.response.close();
-      } catch (IOException e) {
-        // Ignore exception on disconnection
-      }
+      IOUtils.closeQuietly(this.response);
       this.internalOnDisconnect(reason, exception);
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/HttpWebRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/HttpWebRequest.java
@@ -27,6 +27,7 @@ import microsoft.exchange.webservices.data.EWSConstants;
 import microsoft.exchange.webservices.data.core.WebProxy;
 import microsoft.exchange.webservices.data.core.exception.http.EWSHttpException;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -36,7 +37,7 @@ import java.util.Map;
 /**
  * The Class HttpWebRequest.
  */
-public abstract class HttpWebRequest {
+public abstract class HttpWebRequest implements Closeable {
 
   /**
    * The url.

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
@@ -46,6 +46,7 @@ import microsoft.exchange.webservices.data.core.exception.service.local.ServiceX
 import microsoft.exchange.webservices.data.core.exception.xml.XmlException;
 import microsoft.exchange.webservices.data.misc.SoapFaultDetails;
 import microsoft.exchange.webservices.data.security.XmlNodeType;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -644,12 +645,7 @@ public abstract class ServiceRequestBase<T> {
         throw new ServiceRequestException(String.format("The request failed. %s", e.getMessage()), e);
       }
     } catch (Exception e) {
-      try {
-        request.close();
-      } catch (Exception e2) {
-        // Ignore exception while closing the request.
-      }
-
+      IOUtils.closeQuietly(request);
       throw e;
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/FileAttachment.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/FileAttachment.java
@@ -33,6 +33,8 @@ import microsoft.exchange.webservices.data.core.enumeration.misc.XmlNamespace;
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceValidationException;
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceVersionException;
 
+import org.apache.commons.io.IOUtils;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -234,11 +236,7 @@ public final class FileAttachment extends Attachment {
       this.load();
       this.loadToStream.flush();
     } finally {
-      try {
-        this.loadToStream.close();
-      } catch(Exception e) {
-        //ignore exception on close
-      }
+      IOUtils.closeQuietly(this.loadToStream);
       this.loadToStream = null;
     }
 


### PR DESCRIPTION
Add a dependency on commons-io and use it appropriately.

Unfortunately, javax.xml.stream.XMLStreamWriter doesn't implement java.io.Closeable, so IOUtils.closeQuietly couldn't be used in a few places.