### PR TITLE
Fixing an issue where requests could hang indefinitely

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
@@ -401,6 +401,7 @@ public class AutodiscoverService extends ExchangeServiceBase
 
       request.setRequestMethod("GET");
       request.setAllowAutoRedirect(false);
+      request.setTimeout(getTimeout());
 
       // Do NOT allow authentication as this single request will be made over plain HTTP.
       request.setAllowAuthentication(false);

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
@@ -379,7 +379,7 @@ public class AutodiscoverService extends ExchangeServiceBase
    * @throws ServiceLocalException the service local exception
    * @throws URISyntaxException the uRI syntax exception
    */
-  private URI getRedirectUrl(String domainName)
+  public URI getRedirectUrl(String domainName)
       throws EWSHttpException, XMLStreamException, IOException, ServiceLocalException, URISyntaxException {
     String url = String.format(AutodiscoverLegacyHttpUrl, "autodiscover." + domainName);
 
@@ -1524,6 +1524,7 @@ public class AutodiscoverService extends ExchangeServiceBase
         request.setAllowAutoRedirect(false);
         request.setPreAuthenticate(false);
         request.setUseDefaultCredentials(this.getUseDefaultCredentials());
+        request.setTimeout(getTimeout());
 
         prepareCredentials(request);
 

--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
@@ -379,7 +379,7 @@ public class AutodiscoverService extends ExchangeServiceBase
    * @throws ServiceLocalException the service local exception
    * @throws URISyntaxException the uRI syntax exception
    */
-  public URI getRedirectUrl(String domainName)
+  private URI getRedirectUrl(String domainName)
       throws EWSHttpException, XMLStreamException, IOException, ServiceLocalException, URISyntaxException {
     String url = String.format(AutodiscoverLegacyHttpUrl, "autodiscover." + domainName);
 

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeService.java
@@ -3607,7 +3607,8 @@ public class ExchangeService extends ExchangeServiceBase implements IAutodiscove
 
     AutodiscoverService autodiscoverService = new AutodiscoverService(this, requestedServerVersion);
     autodiscoverService.setWebProxy(getWebProxy());
-
+    autodiscoverService.setTimeout(getTimeout());
+    
     autodiscoverService
         .setRedirectionUrlValidationCallback(validateRedirectionUrlCallback);
     autodiscoverService.setEnableScpLookup(this.getEnableScpLookup());


### PR DESCRIPTION
This is my first time generating a pull request, so any feedback would be helpful.

I recently encountered an issue when trying to connect to a mailbox. It turns out the certificate for
https://autodiscover.<domain>/autodiscover/autodiscover.xml 
recently expired. 

This caused the ews code to try and get a redirect url from 
http://autodiscover.<domain>/autodiscover/autodiscover.xml
It turns out, that request has no timeout, and thus, will hang indefinitely. Not sure if it was an oversight or what, but I decided to just set the timeout on this request, as well as another request I found, so hopefully no one else encounters this issue.


