### PR TITLE
Handle relative redirects during autodiscovery

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
+++ b/src/main/java/microsoft/exchange/webservices/data/autodiscover/AutodiscoverService.java
@@ -457,11 +457,10 @@ public class AutodiscoverService extends ExchangeServiceBase
           redirectUrl.setParam(new URI(location));
 
           // Check if URL is SSL and that the path matches.
-          if ((redirectUrl.getParam().getScheme().toLowerCase()
-              .equals("https")) &&
-              (redirectUrl.getParam().getPath()
-                  .equalsIgnoreCase(
-                      AutodiscoverLegacyPath))) {
+          if (((redirectUrl.getParam() != null) &&
+               (redirectUrl.getParam().getScheme() != null) &&
+               redirectUrl.getParam().getScheme().toLowerCase().equals("https")) &&
+              (redirectUrl.getParam().getPath().equalsIgnoreCase(AutodiscoverLegacyPath))) {
             this.traceMessage(TraceFlags.AutodiscoverConfiguration,
                 String.format("Redirection URL found: '%s'",
                     redirectUrl.getParam().toString()));


### PR DESCRIPTION
- Relative redirects will not have a scheme or params and were
  causing NullPointerException in the autodiscovery process.
