### PR TITLE
Add America/Fort_Nelson to known OlsonTimeZones

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/util/TimeZoneUtils.java
+++ b/src/main/java/microsoft/exchange/webservices/data/util/TimeZoneUtils.java
@@ -169,6 +169,7 @@ public final class TimeZoneUtils {
     map.put("America/Eirunepe", "SA Pacific Standard Time");
     map.put("America/El_Salvador", "Central America Standard Time");
     map.put("America/Ensenada", "Pacific Standard Time");
+    map.put("America/Fort_Nelson", "Mountain Standard Time");
     map.put("America/Fort_Wayne", "US Eastern Standard Time");
     map.put("America/Fortaleza", "SA Eastern Standard Time");
     map.put("America/Glace_Bay", "Atlantic Standard Time");

--- a/src/test/java/microsoft/exchange/webservices/data/property/complex/OlsonTimeZoneTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/property/complex/OlsonTimeZoneTest.java
@@ -20,7 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
- 
+
 package microsoft.exchange.webservices.data.property.complex;
 
 import microsoft.exchange.webservices.data.property.complex.time.OlsonTimeZoneDefinition;
@@ -54,7 +54,7 @@ public class OlsonTimeZoneTest {
         final OlsonTimeZoneDefinition olsonTimeZone = new OlsonTimeZoneDefinition(timeZone);
         final String olsonTimeZoneId = olsonTimeZone.getId();
 
-        Assert.assertFalse(StringUtils.isBlank(olsonTimeZoneId));
+        Assert.assertFalse("olsonTimeZoneId for " + timeZoneId + " is blank", StringUtils.isBlank(olsonTimeZoneId));
         Assert.assertEquals(olsonTimeZoneToMsMap.get(timeZoneId), olsonTimeZoneId);
       }
     }


### PR DESCRIPTION
- Add more descriptive assertion failures to OlsonTimeZoneTest
- A new timezone for America/Fort_Nelson was added in tzdata2015g, which
  was included in jdk8u71. This timezone had no analog in the TimeZoneUtils
  map, causing the OlsonTimeZoneTest to fail.