### PR TITLE
Added pooling for ServiceRequestBase

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
@@ -889,4 +889,8 @@ public abstract class ExchangeServiceBase implements Closeable {
       return ExchangeServiceBase.binarySecret;
     }
   }
+
+  public int getMaximumPoolingConnections() {
+    return maximumPoolingConnections;
+  }
 }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
@@ -633,7 +633,13 @@ public abstract class ServiceRequestBase<T> {
   protected HttpWebRequest validateAndEmitRequest() throws Exception {
     this.validate();
 
-    HttpWebRequest request = this.buildEwsHttpWebRequest();
+    HttpWebRequest request;
+    
+    if (service.getMaximumPoolingConnections() > 1) {
+        request = buildEwsHttpPoolingWebRequest();
+    } else {
+        request = buildEwsHttpWebRequest();
+    }
 
     try {
       try {


### PR DESCRIPTION
After using the fix #428 to make the ExchangeService thread safe, a developer can run into a "ServiceRequestException: The request failed. Connection is still allocated".

This can be fixed by using the ExchangeServiceBase#httpPoolingClient for requests.
This Pull-Requests provides a simple differentiation between the ExchangeServiceBase#httpClient and ExchangeServiceBase#httpPoolingClient.