### PR TITLE
Issue #425: Fix hanging StreamingSubscriptionConnection.close()

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/request/HangingServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/HangingServiceRequestBase.java
@@ -266,7 +266,7 @@ public abstract class HangingServiceRequestBase<T> extends ServiceRequestBase<T>
    */
   public void disconnect() {
     synchronized (this) {
-      IOUtils.closeQuietly(this.response);
+      this.response.releaseConnection();
       this.disconnect(HangingRequestDisconnectReason.UserInitiated, null);
     }
   }
@@ -279,7 +279,7 @@ public abstract class HangingServiceRequestBase<T> extends ServiceRequestBase<T>
    */
   public void disconnect(HangingRequestDisconnectReason reason, Exception exception) {
     if (this.isConnected()) {
-      IOUtils.closeQuietly(this.response);
+      this.response.releaseConnection();
       this.internalOnDisconnect(reason, exception);
     }
   }

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/HttpClientWebRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/HttpClientWebRequest.java
@@ -94,6 +94,13 @@ public class HttpClientWebRequest extends HttpWebRequest {
     httpPost = null;
   }
 
+  @Override
+  public void releaseConnection() {
+    if (httpPost != null) {
+      httpPost.releaseConnection();
+    }
+  }
+
   /**
    * Prepares the request by setting appropriate headers, authentication, timeouts, etc.
    */

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/HttpWebRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/HttpWebRequest.java
@@ -495,6 +495,8 @@ public abstract class HttpWebRequest implements Closeable {
    */
   public abstract void close() throws IOException;
 
+  public abstract void releaseConnection();
+
   /**
    * Prepare connection.
    */


### PR DESCRIPTION
StreamingSubscriptionConnection.close() calls HttpWebRequest.close() which will first
attempts to consume the response before releasing the connection. This unfortunately
will hang since the notification reader thread is still blocked reading from the same 
connection. The fix is to just the connection without consuming the response entity.