### PR TITLE
Fix the "contacts:MSExchageCertificate" typo 

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/service/schema/ContactSchema.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/service/schema/ContactSchema.java
@@ -306,7 +306,7 @@ public class ContactSchema extends ItemSchema {
      * The MSExchangeCertificate.
      */
 
-    String MSExchangeCertificate = "contacts:MSExchageCertificate";
+    String MSExchangeCertificate = "contacts:MSExchangeCertificate";
 
     /**
      * The DirectoryId.


### PR DESCRIPTION
Should be "contacts:MSExchangeCertificate".

Otherwise Exchange will reject all SOAP request containing this FieldURI
