### PR TITLE
Add support for UseDefaultCredentials Option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
         <jacoco-maven-plugin.version>0.7.5.201505241946</jacoco-maven-plugin.version>
         <!--  Dependencies [COMPILE]:  -->
         <httpclient.version>4.4.1</httpclient.version>
+        <httpclient-win.version>4.4.1</httpclient-win.version>
         <httpcore.version>4.4.1</httpcore.version>
         <commons-logging.version>1.2</commons-logging.version>
         <joda-time.version>2.8</joda-time.version>
@@ -217,6 +218,12 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient-win</artifactId>
+            <version>${httpclient-win.version}</version>
         </dependency>
         
         <dependency>

--- a/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/ExchangeServiceBase.java
@@ -69,7 +69,9 @@ import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.WinHttpClients;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 
@@ -171,7 +173,7 @@ public abstract class ExchangeServiceBase implements Closeable {
    * every other constructor.
    */
   protected ExchangeServiceBase() {
-    setUseDefaultCredentials(true);
+    setUseDefaultCredentials(false);
     initializeHttpClient();
     initializeHttpContext();
   }
@@ -200,7 +202,7 @@ public abstract class ExchangeServiceBase implements Closeable {
     HttpClientConnectionManager httpConnectionManager = new BasicHttpClientConnectionManager(registry);
     AuthenticationStrategy authStrategy = new CookieProcessingTargetAuthenticationStrategy();
 
-    httpClient = HttpClients.custom()
+    httpClient = constructHttpClientBuilder()
       .setConnectionManager(httpConnectionManager)
       .setTargetAuthenticationStrategy(authStrategy)
       .build();
@@ -213,10 +215,20 @@ public abstract class ExchangeServiceBase implements Closeable {
     httpConnectionManager.setDefaultMaxPerRoute(maximumPoolingConnections);
     AuthenticationStrategy authStrategy = new CookieProcessingTargetAuthenticationStrategy();
 
-    httpPoolingClient = HttpClients.custom()
+    httpPoolingClient = constructHttpClientBuilder()
         .setConnectionManager(httpConnectionManager)
         .setTargetAuthenticationStrategy(authStrategy)
         .build();
+  }
+  
+  private HttpClientBuilder constructHttpClientBuilder(){
+	  if(useDefaultCredentials) {
+		  if(System.getProperty("os.name").toLowerCase().contains("windows")) {
+			  return WinHttpClients.custom();
+		  }
+	  }
+
+	  return HttpClients.custom();
   }
 
   /**

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/HttpClientWebRequest.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/HttpClientWebRequest.java
@@ -35,6 +35,7 @@ import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.impl.auth.win.WindowsCredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.util.EntityUtils;
@@ -152,6 +153,10 @@ public class HttpClientWebRequest extends HttpWebRequest {
       credentialsProvider.setCredentials(new AuthScope(AuthScope.ANY), webServiceCredentials);
     }
 
+    if(isUseDefaultCredentials() && System.getProperty("os.name").toLowerCase().contains("windows")) {
+    	credentialsProvider = new WindowsCredentialsProvider(credentialsProvider);
+    }
+    
     httpContext.setCredentialsProvider(credentialsProvider);
 
     httpPost.setConfig(requestConfigBuilder.build());


### PR DESCRIPTION
Allow Integrated Windows Authentication to be used when authenticating
to the Exchange server.

I apologize in advance if any part of this pull request is improper. I am very inexperienced with Online Collaboration. I considered creating a JUnit test for the new functionality but I didn't know how I could test the code without a server to contact. I tried to minimize the impact of this code so it only affects users who have enabled the UseDefaultCredentials feature. I disabled it by default to mirror the .NET API.