### PR TITLE
Parsing UserConfiguration dictionary entry with null value fails with ServiceXmlDeserializationException

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/property/complex/UserConfigurationDictionary.java
+++ b/src/main/java/microsoft/exchange/webservices/data/property/complex/UserConfigurationDictionary.java
@@ -476,8 +476,7 @@ public final class UserConfigurationDictionary extends ComplexProperty
 
     String nil = reader.readAttributeValue(XmlNamespace.XmlSchemaInstance,
         XmlAttributeNames.Nil);
-    boolean hasValue = (nil == null)
-        || (!nil.getClass().equals(Boolean.TYPE));
+    boolean hasValue = (nil == null);
     if (hasValue) {
       value = this.getDictionaryObject(reader);
     }

--- a/src/test/java/microsoft/exchange/webservices/data/core/request/UserConfigurationTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/core/request/UserConfigurationTest.java
@@ -1,0 +1,41 @@
+package microsoft.exchange.webservices.data.core.request;
+
+import microsoft.exchange.webservices.base.BaseTest;
+import microsoft.exchange.webservices.data.core.EwsServiceXmlReader;
+import microsoft.exchange.webservices.data.core.enumeration.service.ServiceResult;
+import microsoft.exchange.webservices.data.core.response.GetUserConfigurationResponse;
+import microsoft.exchange.webservices.data.core.response.ServiceResponseCollection;
+import microsoft.exchange.webservices.data.misc.OutParam;
+import microsoft.exchange.webservices.data.property.complex.UserConfigurationDictionary;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.InputStream;
+
+@RunWith(JUnit4.class)
+public class UserConfigurationTest extends BaseTest {
+
+  @Test
+  public void testNilDictionaryEntry() throws Exception {
+    GetUserConfigurationRequest request = new GetUserConfigurationRequest(exchangeServiceMock);
+    request.setName("Calendar");
+
+    InputStream inputStream = getClass().getResourceAsStream("/nil.xml");
+    EwsServiceXmlReader ewsXmlReader = new EwsServiceXmlReader(inputStream, exchangeServiceMock);
+    ServiceResponseCollection<GetUserConfigurationResponse> responses = request.readResponse(ewsXmlReader);
+
+    Assert.assertEquals(ServiceResult.Success, responses.getOverallResult());
+    Assert.assertNull(getDictionaryEntryValue(responses, "RequestInPolicy"));
+  }
+
+  private Object getDictionaryEntryValue(ServiceResponseCollection<GetUserConfigurationResponse> responses,
+                                         String requestInPolicy) {
+    UserConfigurationDictionary dictionary = responses.iterator().next().getUserConfiguration().getDictionary();
+    OutParam<Object> value = new OutParam<Object>();
+    dictionary.tryGetValue(requestInPolicy, value);
+    return value.getParam();
+  }
+
+}

--- a/src/test/resources/nil.xml
+++ b/src/test/resources/nil.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+    <s:Header>
+        <h:ServerVersionInfo xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types"
+                             xmlns="http://schemas.microsoft.com/exchange/services/2006/types"
+                             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                             MajorVersion="14" MinorVersion="3" MajorBuildNumber="266" MinorBuildNumber="1"
+                             Version="Exchange2010_SP2"/>
+    </s:Header>
+    <s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        <m:GetUserConfigurationResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages"
+                                        xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types">
+            <m:ResponseMessages>
+                <m:GetUserConfigurationResponseMessage ResponseClass="Success">
+                    <m:ResponseCode>NoError</m:ResponseCode>
+                    <m:UserConfiguration>
+                        <t:UserConfigurationName Name="Calendar">
+                            <t:DistinguishedFolderId Id="calendar">
+                                <t:Mailbox>
+                                    <t:EmailAddress>room@company.com</t:EmailAddress>
+                                </t:Mailbox>
+                            </t:DistinguishedFolderId>
+                        </t:UserConfigurationName>
+                        <t:ItemId
+                                Id="AAMkADM1ZTI1ZDFkLTVhYzAtNGM1OS1hNWU0LTRkYWMyN2IxY2NhYgBGAAAAAABpRr8ivxS3SpNwMWdbqv/CBwBC8RoCDnbYSbjqYWwdG9viAKfx+eOZAABC8RoCDnbYSbjqYWwdG9viAKfx+6f2AAA="
+                                ChangeKey="CQAAABYAAADXBP/PKsWQRKG/Fv+wtIlbAAASQjNo"/>
+                        <t:Dictionary>
+                            <t:DictionaryEntry>
+                                <t:DictionaryKey>
+                                    <t:Type>String</t:Type>
+                                    <t:Value>RequestInPolicy</t:Value>
+                                </t:DictionaryKey>
+                                <t:DictionaryValue xsi:nil="true"/>
+                            </t:DictionaryEntry>
+                            <t:DictionaryEntry>
+                                <t:DictionaryKey>
+                                    <t:Type>String</t:Type>
+                                    <t:Value>RemovePrivateProperty</t:Value>
+                                </t:DictionaryKey>
+                                <t:DictionaryValue>
+                                    <t:Type>Boolean</t:Type>
+                                    <t:Value>true</t:Value>
+                                </t:DictionaryValue>
+                            </t:DictionaryEntry>
+                        </t:Dictionary>
+                    </m:UserConfiguration>
+                </m:GetUserConfigurationResponseMessage>
+            </m:ResponseMessages>
+        </m:GetUserConfigurationResponse>
+    </s:Body>
+</s:Envelope>


### PR DESCRIPTION
Parsing the following dictionary entry from a UserConfiguration response

```
<t:DictionaryEntry>
    <t:DictionaryKey>
        <t:Type>String</t:Type>
        <t:Value>RequestInPolicy</t:Value>
    </t:DictionaryKey>
    <t:DictionaryValue xsi:nil="true"/>
</t:DictionaryEntry>

```
fails with the following exception

```
microsoft.exchange.webservices.data.core.exception.service.local.ServiceXmlDeserializationException: The expected XML node type was START_ELEMENT, but the actual type is END_ELEMENT.

	at microsoft.exchange.webservices.data.core.EwsXmlReader.read(EwsXmlReader.java:227)
	at microsoft.exchange.webservices.data.core.EwsXmlReader.internalReadElement(EwsXmlReader.java:134)
	at microsoft.exchange.webservices.data.core.EwsXmlReader.readStartElement(EwsXmlReader.java:614)
	at microsoft.exchange.webservices.data.property.complex.UserConfigurationDictionary.getObjectType(UserConfigurationDictionary.java:561)
	at microsoft.exchange.webservices.data.property.complex.UserConfigurationDictionary.getDictionaryObject(UserConfigurationDictionary.java:498)
	at microsoft.exchange.webservices.data.property.complex.UserConfigurationDictionary.loadEntry(UserConfigurationDictionary.java:482)
	at microsoft.exchange.webservices.data.property.complex.UserConfigurationDictionary.tryReadElementFromXml(UserConfigurationDictionary.java:450)
	at microsoft.exchange.webservices.data.property.complex.ComplexProperty.internalLoadFromXml(ComplexProperty.java:260)
	at microsoft.exchange.webservices.data.property.complex.ComplexProperty.loadFromXml(ComplexProperty.java:211)
	at microsoft.exchange.webservices.data.property.complex.UserConfigurationDictionary.loadFromXml(UserConfigurationDictionary.java:428)
	at microsoft.exchange.webservices.data.property.complex.ComplexProperty.loadFromXml(ComplexProperty.java:311)
	at microsoft.exchange.webservices.data.misc.UserConfiguration.loadFromXml(UserConfiguration.java:604)
	at microsoft.exchange.webservices.data.core.response.GetUserConfigurationResponse.readElementsFromXml(GetUserConfigurationResponse.java:62)
	at microsoft.exchange.webservices.data.core.response.ServiceResponse.loadFromXml(ServiceResponse.java:133)
	at microsoft.exchange.webservices.data.core.request.MultiResponseServiceRequest.parseResponse(MultiResponseServiceRequest.java:76)
	at microsoft.exchange.webservices.data.core.request.MultiResponseServiceRequest.parseResponse(MultiResponseServiceRequest.java:44)
	at microsoft.exchange.webservices.data.core.request.ServiceRequestBase.readResponse(ServiceRequestBase.java:434)
```

Removed wrong condition for determining if the dictionary entry has a value. (`nil.getClass()` will always return `String` which will always be different from `Boolean.TYPE`)