### PR TITLE
issue #580 : support for configured TLS and cipherSuites

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsSSLProtocolSocketFactory.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsSSLProtocolSocketFactory.java
@@ -26,6 +26,7 @@ package microsoft.exchange.webservices.data.core;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.ssl.SSLContexts;
+import org.apache.http.util.TextUtils;
 
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -103,6 +104,22 @@ public class EwsSSLProtocolSocketFactory extends SSLConnectionSocketFactory {
     this.sslcontext = context;
   }
 
+  /**
+   * Constructor for EasySSLProtocolSocketFactory.
+   *
+   * @param context          SSL context
+   * @param supportedProtocols protocol from sys prop
+   * @param supportedCipherSuites cipherSuites from sys prop
+   * @param hostnameVerifier hostname verifier
+   */
+  public EwsSSLProtocolSocketFactory(
+          SSLContext context,String[] supportedProtocols, String[] supportedCipherSuites,
+          HostnameVerifier hostnameVerifier
+  ) {
+    super(context,supportedProtocols,supportedCipherSuites, hostnameVerifier);
+    this.sslcontext = context;
+  }
+
 
   /**
    * Create and configure SSL protocol socket factory using default hostname verifier.
@@ -129,7 +146,22 @@ public class EwsSSLProtocolSocketFactory extends SSLConnectionSocketFactory {
     TrustManager trustManager, HostnameVerifier hostnameVerifier
   ) throws GeneralSecurityException {
     SSLContext sslContext = createSslContext(trustManager);
-    return new EwsSSLProtocolSocketFactory(sslContext, hostnameVerifier);
+
+    //read system properties
+    String[] keepAliveStrategyCopy;
+    keepAliveStrategyCopy = split(System.getProperty("https.protocols"));
+    String[] targetAuthStrategyCopy;
+    targetAuthStrategyCopy = split(System.getProperty("https.cipherSuites"));
+
+    if (null != keepAliveStrategyCopy || null != targetAuthStrategyCopy) {
+      return new EwsSSLProtocolSocketFactory(sslContext,keepAliveStrategyCopy,targetAuthStrategyCopy, hostnameVerifier);
+    } else {
+      return new EwsSSLProtocolSocketFactory(sslContext, hostnameVerifier);
+    }
+  }
+
+  private static String[] split(String s) {
+    return TextUtils.isBlank(s)?null:s.split(" *, *");
   }
 
   /**


### PR DESCRIPTION
This fix is for https://github.com/OfficeDev/ews-java-api/issues/580
This PR has fix as per #2 below.

 Few options to fix this are:
1] stop setting ConnectionManager and set useSystemProperties() while building HttpClients, in which case HttpClientBuilder will invoke the code to read systemProperties.
reuseStrategyCopy = new SSLConnectionSocketFactory((SSLSocketFactory)SSLSocketFactory.getDefault(), keepAliveStrategyCopy, targetAuthStrategyCopy, (HostnameVerifier)proxyAuthStrategyCopy);

2] Another approach is to update EwsSSLProtocolSocketFactory.build() to support the call to SSLConnectionSocketFactory constructor using SSL protocol and cipherSuite.