### PR TITLE
Fix #746

### DIFF
--- a/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceXmlWriter.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/EwsServiceXmlWriter.java
@@ -98,9 +98,9 @@ public class EwsServiceXmlWriter implements IDisposable {
    */
   public EwsServiceXmlWriter(ExchangeServiceBase service, OutputStream stream) throws XMLStreamException {
     this.service = service;
-    XMLOutputFactory xmlof = XMLOutputFactory.newInstance();
+    XMLOutputFactory xmlof = XMLOutputFactory.newDefaultFactory();
+    xmlof.setProperty("escapeCharacters", false);
     xmlWriter = xmlof.createXMLStreamWriter(stream, "utf-8");
-
   }
 
   /**


### PR DESCRIPTION
Fixes #746 

Root cause is the line 85 of WSSecurityBasedCredentials.java:
```
  protected static final String wsAddressingHeadersFormat =
      "<wsa:Action soap:mustUnderstand='1'>http://schemas.microsoft.com/exchange/services/2006/messages/%s</wsa:Action>"
          +
          "<wsa:ReplyTo><wsa:Address>http://www.w3.org/2005/08/addressing/anonymous</wsa:Address>" +
          "</wsa:ReplyTo>" +
          "<wsa:To soap:mustUnderstand='1'>%s</wsa:To>";
```
This string is passed on to the xmlWriter in line 201:
```
    // Format the WS-Addressing headers.
    String wsAddressingHeaders = String.format(
        WSSecurityBasedCredentials.wsAddressingHeadersFormat,
        webMethodName, this.ewsUrl);
    
    // And write them out...
    xmlWriter.writeCharacters(wsAddressingHeaders);
```
The xmlWriter however, will escape the characters `<` and `>` to its corresponding html escape values `&lt;` and `&gt;` and then send a malformed xml body to the exchangeService. The backend can't parse the xml body and fails with an internal server error.

This fix simply uses the default xml writer implementation and instructs it to not escape characters.