### PR TITLE
#773 Jakarta compatible version of ews-java-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,18 @@
         </dependency>
 
         <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>

--- a/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
+++ b/src/main/java/microsoft/exchange/webservices/data/core/request/ServiceRequestBase.java
@@ -51,7 +51,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import javax.xml.stream.XMLStreamException;
-import javax.xml.ws.http.HTTPException;
+import jakarta.xml.ws.http.HTTPException;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/src/test/java/microsoft/exchange/webservices/data/property/complex/TimeChangeTest.java
+++ b/src/test/java/microsoft/exchange/webservices/data/property/complex/TimeChangeTest.java
@@ -23,7 +23,7 @@ package microsoft.exchange.webservices.data.property.complex;
 import java.util.Calendar;
 import java.util.TimeZone;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 import microsoft.exchange.webservices.data.core.EwsUtilities;
 import microsoft.exchange.webservices.data.misc.Time;


### PR DESCRIPTION
See https://github.com/OfficeDev/ews-java-api/issues/773

Basically this change does the following:
- Change two import statements from javax to jakarta
- Add required dependencies to
-- jakarta.xml.bind:jakarta.xml.bind-api (3.0.1)
-- jakarta.xml.ws:jakarta.xml.ws-api (3.0.1)

Unfortunately I did not find out how the existing code manages the above dependencies to include the required modules.
